### PR TITLE
Create Angular package exposing ApiEditorComponent

### DIFF
--- a/front-end/studio/.gitignore
+++ b/front-end/studio/.gitignore
@@ -45,3 +45,5 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+/.ng_pkg_build/
+*.tgz

--- a/front-end/studio/package.json
+++ b/front-end/studio/package.json
@@ -12,10 +12,11 @@
     "ng": "ng",
     "start": "ng serve --port 8888 --aot",
     "debug": "ng serve --port 8888 --sourcemap -dev -v",
-    "build": "ng build -prod"
+    "build": "ng build -prod",
+    "package": "ng-packagr -p package.json"
   },
   "private": true,
-  "dependencies": {
+  "peerDependencies": {
     "@angular/animations": "^5.2.0",
     "@angular/common": "^5.2.0",
     "@angular/compiler": "^5.2.0",
@@ -24,22 +25,45 @@
     "@angular/platform-browser": "^5.2.0",
     "@angular/platform-browser-dynamic": "^5.2.0",
     "@angular/router": "^5.2.0",
-    "patternfly": "3.40.0",
-    "oai-ts-core": "0.2.15",
-    "oai-ts-commands": "0.2.28",
+    "brace": "0.11.1",
     "core-js": "^2.4.1",
     "ngx-bootstrap": "2.0.2",
-    "brace": "0.11.1",
-    "yamljs": "0.3.0",
+    "oai-ts-commands": "0.2.28",
+    "oai-ts-core": "0.2.15",
+    "patternfly": "3.40.0",
     "rxjs": "^5.5.6",
+    "yamljs": "0.3.0",
     "zone.js": "^0.8.19"
   },
   "devDependencies": {
+    "@angular/animations": "^5.2.0",
     "@angular/cli": "1.6.8",
+    "@angular/common": "^5.2.0",
+    "@angular/compiler": "^5.2.0",
     "@angular/compiler-cli": "^5.2.0",
+    "@angular/core": "^5.2.0",
+    "@angular/forms": "^5.2.0",
     "@angular/language-service": "^5.2.0",
+    "@angular/platform-browser": "^5.2.0",
+    "@angular/platform-browser-dynamic": "^5.2.0",
+    "@angular/router": "^5.2.0",
     "@types/node": "~6.0.60",
+    "brace": "0.11.1",
+    "core-js": "^2.4.1",
+    "ng-packagr": "^2.0.0",
+    "ngx-bootstrap": "2.0.2",
+    "oai-ts-commands": "0.2.28",
+    "oai-ts-core": "0.2.15",
+    "patternfly": "3.40.0",
+    "rxjs": "^5.5.6",
     "ts-node": "~4.1.0",
-    "typescript": "~2.5.3"
+    "typescript": "~2.5.3",
+    "yamljs": "0.3.0",
+    "zone.js": "^0.8.19"
+  },
+  "ngPackage": {
+    "lib": {
+      "entryFile": "public_api.ts"
+    }
   }
 }

--- a/front-end/studio/public_api.ts
+++ b/front-end/studio/public_api.ts
@@ -1,0 +1,129 @@
+import { ModuleWithProviders, NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { BsDropdownModule, BsModalService, ModalModule } from 'ngx-bootstrap';
+
+import { AceEditorComponent } from './src/app/components/common/ace-editor.component';
+import { AddDefinitionDialogComponent } from './src/app/pages/apis/{apiId}/editor/_components/dialogs/add-definition.component';
+import { AddExample20DialogComponent } from './src/app/pages/apis/{apiId}/editor/_components/dialogs/add-example-20.component';
+import { AddExampleDialogComponent } from './src/app/pages/apis/{apiId}/editor/_components/dialogs/add-example.component';
+import { AddFormDataParamDialogComponent } from './src/app/pages/apis/{apiId}/editor/_components/dialogs/add-formData-param.component';
+import { AddMediaTypeDialogComponent } from './src/app/pages/apis/{apiId}/editor/_components/dialogs/add-media-type.component';
+import { AddPathDialogComponent } from './src/app/pages/apis/{apiId}/editor/_components/dialogs/add-path.component';
+import { AddQueryParamDialogComponent } from './src/app/pages/apis/{apiId}/editor/_components/dialogs/add-query-param.component';
+import { AddResponseDialogComponent } from './src/app/pages/apis/{apiId}/editor/_components/dialogs/add-response.component';
+import { AddSchemaPropertyDialogComponent } from './src/app/pages/apis/{apiId}/editor/_components/dialogs/add-schema-property.component';
+import { AddServerDialogComponent } from './src/app/pages/apis/{apiId}/editor/_components/dialogs/add-server.component';
+import { AddTagDialogComponent } from './src/app/pages/apis/{apiId}/editor/_components/dialogs/add-tag.component';
+import { ApiEditorComponent } from './src/app/pages/apis/{apiId}/editor/editor.component';
+import { CloneDefinitionDialogComponent } from './src/app/pages/apis/{apiId}/editor/_components/dialogs/clone-definition.component';
+import { ClonePathDialogComponent } from './src/app/pages/apis/{apiId}/editor/_components/dialogs/clone-path.component';
+import { CodeEditorComponent, CodeEditorTheme } from './src/app/components/common/code-editor.component';
+import { ContentComponent } from './src/app/pages/apis/{apiId}/editor/_components/forms/operation/content.component';
+import { ContextHelpComponent } from './src/app/pages/apis/{apiId}/editor/_components/common/context-help.component';
+import { CopyUrlDialogComponent } from './src/app/components/dialogs/copy-url.component';
+import { DefinitionFormComponent } from './src/app/pages/apis/{apiId}/editor/_components/forms/definition-form.component';
+import { DefinitionItemComponent } from './src/app/pages/apis/{apiId}/editor/_components/forms/definition-item.component';
+import { DropDownComponent } from './src/app/components/common/drop-down.component';
+import { EditableApiDefinition } from './src/app/models/api.model';
+import { EditExample20DialogComponent } from './src/app/pages/apis/{apiId}/editor/_components/dialogs/edit-example-20.component';
+import { EditExampleDialogComponent } from './src/app/pages/apis/{apiId}/editor/_components/dialogs/edit-example.component';
+import { EditorMasterComponent } from './src/app/pages/apis/{apiId}/editor/_components/master.component';
+import { FormErrorMessageComponent } from './src/app/components/common/form-error-message.component';
+import { IconButtonComponent } from './src/app/pages/apis/{apiId}/editor/_components/common/icon-button.component';
+import { InlineTextAreaComponent } from './src/app/pages/apis/{apiId}/editor/_components/common/inline-textarea-editor.component';
+import { InlineTextEditorComponent } from './src/app/pages/apis/{apiId}/editor/_components/common/inline-text-editor.component';
+import { LicenseService } from './src/app/pages/apis/{apiId}/editor/_services/license.service';
+import { Main20FormComponent, Main30FormComponent } from './src/app/pages/apis/{apiId}/editor/_components/forms/main-form.component';
+import { Operation30FormComponent } from './src/app/pages/apis/{apiId}/editor/_components/forms/operation-30-form.component';
+import { OperationFormComponent } from './src/app/pages/apis/{apiId}/editor/_components/forms/operation-form.component';
+import { ParamRowComponent } from './src/app/pages/apis/{apiId}/editor/_components/forms/operation/param-row.component';
+import { PathFormComponent } from './src/app/pages/apis/{apiId}/editor/_components/forms/path-form.component';
+import { PathItemComponent } from './src/app/pages/apis/{apiId}/editor/_components/common/path-item.component';
+import { ProblemFormComponent } from './src/app/pages/apis/{apiId}/editor/_components/forms/problem-form.component';
+import { PropertyRowComponent } from './src/app/pages/apis/{apiId}/editor/_components/forms/definition/property-row.component';
+import { RenameDefinitionDialogComponent } from './src/app/pages/apis/{apiId}/editor/_components/dialogs/rename-definition.component';
+import { ResponseItemComponent } from './src/app/pages/apis/{apiId}/editor/_components/common/response-item.component';
+import { ResponseRow30Component } from './src/app/pages/apis/{apiId}/editor/_components/forms/operation/response-row-30.component';
+import { ResponseRowComponent } from './src/app/pages/apis/{apiId}/editor/_components/forms/operation/response-row.component';
+import { SchemaTypeComponent } from './src/app/pages/apis/{apiId}/editor/_components/common/schema-type.component';
+import { SearchComponent } from './src/app/pages/apis/{apiId}/editor/_components/common/search.component';
+import { SecurityRequirementDialogComponent } from './src/app/pages/apis/{apiId}/editor/_components/dialogs/security-requirement.component';
+import { SecurityScheme20DialogComponent } from './src/app/pages/apis/{apiId}/editor/_components/dialogs/security-scheme-20.component';
+import { SecurityScheme30DialogComponent } from './src/app/pages/apis/{apiId}/editor/_components/dialogs/security-scheme-30.component';
+import { SelectionService } from './src/app/pages/apis/{apiId}/editor/_services/selection.service';
+import { ServersSectionComponent } from './src/app/pages/apis/{apiId}/editor/_components/forms/shared/servers.component';
+import { ServerUrlComponent } from './src/app/pages/apis/{apiId}/editor/_components/common/server-url.component';
+import { SetContactDialogComponent } from './src/app/pages/apis/{apiId}/editor/_components/dialogs/set-contact.component';
+import { SetLicenseDialogComponent } from './src/app/pages/apis/{apiId}/editor/_components/dialogs/set-license.component';
+import { ValidationIconComponent } from './src/app/pages/apis/{apiId}/editor/_components/common/validation-icon.component';
+
+export { ApiEditorComponent, EditableApiDefinition };
+
+@NgModule({
+  declarations: [
+    AceEditorComponent,
+    AddDefinitionDialogComponent,
+    AddExample20DialogComponent,
+    AddExampleDialogComponent,
+    AddFormDataParamDialogComponent,
+    AddMediaTypeDialogComponent,
+    AddPathDialogComponent,
+    AddQueryParamDialogComponent,
+    AddResponseDialogComponent,
+    AddSchemaPropertyDialogComponent,
+    AddServerDialogComponent,
+    AddTagDialogComponent,
+    ApiEditorComponent,
+    CloneDefinitionDialogComponent,
+    ClonePathDialogComponent,
+    CodeEditorComponent,
+    ContentComponent,
+    ContextHelpComponent,
+    CopyUrlDialogComponent,
+    DefinitionFormComponent,
+    DefinitionItemComponent,
+    DropDownComponent,
+    EditExample20DialogComponent,
+    EditExampleDialogComponent,
+    EditorMasterComponent,
+    FormErrorMessageComponent,
+    IconButtonComponent,
+    InlineTextAreaComponent,
+    InlineTextEditorComponent,
+    Main20FormComponent,
+    Main30FormComponent,
+    Operation30FormComponent,
+    OperationFormComponent,
+    ParamRowComponent,
+    PathFormComponent,
+    PathItemComponent,
+    ProblemFormComponent,
+    PropertyRowComponent,
+    RenameDefinitionDialogComponent,
+    ResponseItemComponent,
+    ResponseRow30Component,
+    ResponseRowComponent,
+    SchemaTypeComponent,
+    SearchComponent,
+    SecurityRequirementDialogComponent,
+    SecurityScheme20DialogComponent,
+    SecurityScheme30DialogComponent,
+    ServersSectionComponent,
+    ServerUrlComponent,
+    SetContactDialogComponent,
+    SetLicenseDialogComponent,
+    ValidationIconComponent,
+  ],
+  imports: [
+    CommonModule, FormsModule, ModalModule, BsDropdownModule
+  ],
+  exports: [
+    ApiEditorComponent
+  ],
+  providers: [
+    LicenseService, BsModalService, SelectionService
+  ]
+})
+export class ApicurioEditorModule {
+}

--- a/front-end/studio/src/app/components/common/ace-editor.component.ts
+++ b/front-end/studio/src/app/components/common/ace-editor.component.ts
@@ -56,8 +56,8 @@ export class AceEditorComponent implements ControlValueAccessor, OnInit, OnDestr
 
     /**
      * C'tor.
-     * @param {ElementRef} elementRef
-     * @param {NgZone} zone
+     * @param elementRef
+     * @param zone
      */
     constructor(elementRef: ElementRef, private zone: NgZone) {
         let el = elementRef.nativeElement;

--- a/front-end/studio/src/app/components/dialogs/copy-url.component.ts
+++ b/front-end/studio/src/app/components/dialogs/copy-url.component.ts
@@ -58,7 +58,7 @@ export class CopyUrlDialogComponent {
 
     /**
      * Returns true if the dialog is open.
-     * @return {boolean}
+     * @return
      */
     public isOpen(): boolean {
         return this._isOpen;

--- a/front-end/studio/src/app/components/page-base.component.ts
+++ b/front-end/studio/src/app/components/page-base.component.ts
@@ -19,6 +19,7 @@ import {OnDestroy, OnInit} from "@angular/core";
 import {ActivatedRoute} from "@angular/router";
 import {Observable} from "rxjs/Observable";
 import {Title} from "@angular/platform-browser";
+import 'rxjs/add/observable/combineLatest';
 
 export class DataMap {
     [key: string]: boolean;

--- a/front-end/studio/src/app/pages/apis/apis.page.ts
+++ b/front-end/studio/src/app/pages/apis/apis.page.ts
@@ -78,7 +78,7 @@ export class ApisPageComponent extends AbstractPageComponent implements OnDestro
     public allApis: Api[] = [];
     public filteredApis: Api[];
     public selectedApis: Api[];
-    public filters: Filters = new Filters();
+    private filters: Filters = new Filters();
 
     public numApisToDelete: number = 0;
 

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/common/inline-editor.base.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/common/inline-editor.base.ts
@@ -261,7 +261,7 @@ export abstract class TextAreaEditorComponent extends TextInputEditorComponent {
 
     /**
      * Subclasses can override this to provide validation status of the current value.
-     * @return {boolean}
+     * @return
      */
     protected isValid(): boolean {
         return true;

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/add-definition.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/add-definition.component.ts
@@ -115,7 +115,7 @@ export class AddDefinitionDialogComponent {
 
     /**
      * Returns true if the dialog is open.
-     * @return {boolean}
+     * @return
      */
     public isOpen(): boolean {
         return this._isOpen;
@@ -145,7 +145,7 @@ export class AddDefinitionDialogComponent {
     /**
      * Returns true if it's possible to format the example definition (it must be non-null and
      * syntactically valid).
-     * @return {boolean}
+     * @return
      */
     public isExampleDefinitionFormattable(): boolean {
         return this.exampleFormattable;
@@ -154,7 +154,7 @@ export class AddDefinitionDialogComponent {
     /**
      * Returns true if the example definition added by the user in the Add Definition modal
      * dialog is valid (syntactically).
-     * @return {boolean}
+     * @return
      */
     public isExampleDefinitionValid(): boolean {
         return this.exampleValid;

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/add-example-20.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/add-example-20.component.ts
@@ -121,7 +121,7 @@ export class AddExample20DialogComponent {
 
     /**
      * Returns true if the dialog is open.
-     * @return {boolean}
+     * @return
      */
     public isOpen(): boolean {
         return this._isOpen;

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/add-example.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/add-example.component.ts
@@ -121,7 +121,7 @@ export class AddExampleDialogComponent {
 
     /**
      * Returns true if the dialog is open.
-     * @return {boolean}
+     * @return
      */
     public isOpen(): boolean {
         return this._isOpen;

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/add-formData-param.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/add-formData-param.component.ts
@@ -75,7 +75,7 @@ export class AddFormDataParamDialogComponent {
 
     /**
      * Returns true if the dialog is open.
-     * @return {boolean}
+     * @return
      */
     public isOpen(): boolean {
         return this._isOpen;

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/add-media-type.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/add-media-type.component.ts
@@ -76,7 +76,7 @@ export class AddMediaTypeDialogComponent {
 
     /**
      * Returns true if the dialog is open.
-     * @return {boolean}
+     * @return
      */
     public isOpen(): boolean {
         return this._isOpen;

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/add-path.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/add-path.component.ts
@@ -20,7 +20,7 @@ import {ModalDirective} from "ngx-bootstrap";
 import {OasDocument, OasLibraryUtils} from "oai-ts-core";
 import {FormControl} from "@angular/forms";
 import {Subject} from "rxjs/Subject";
-
+import 'rxjs/add/operator/distinctUntilChanged';
 
 @Component({
     moduleId: module.id,

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/add-path.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/add-path.component.ts
@@ -44,8 +44,8 @@ export class AddPathDialogComponent {
 
     /**
      * Called to open the dialog.
-     * @param {OasDocument} document
-     * @param {string} path
+     * @param document
+     * @param path
      */
     public open(document: OasDocument, path?: string): void {
         this.path = path;
@@ -102,7 +102,7 @@ export class AddPathDialogComponent {
 
     /**
      * Returns true if the dialog is open.
-     * @return {boolean}
+     * @return
      */
     public isOpen(): boolean {
         return this._isOpen;

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/add-query-param.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/add-query-param.component.ts
@@ -75,7 +75,7 @@ export class AddQueryParamDialogComponent {
 
     /**
      * Returns true if the dialog is open.
-     * @return {boolean}
+     * @return
      */
     public isOpen(): boolean {
         return this._isOpen;

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/add-response.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/add-response.component.ts
@@ -75,7 +75,7 @@ export class AddResponseDialogComponent {
 
     /**
      * Returns true if the dialog is open.
-     * @return {boolean}
+     * @return
      */
     public isOpen(): boolean {
         return this._isOpen;
@@ -83,7 +83,7 @@ export class AddResponseDialogComponent {
 
     /**
      * Returns true if today is the first of April.  (teapot related)
-     * @return {boolean}
+     * @return
      */
     public isAprilFirst(): boolean {
         let d: Date = new Date();

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/add-schema-property.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/add-schema-property.component.ts
@@ -75,7 +75,7 @@ export class AddSchemaPropertyDialogComponent {
 
     /**
      * Returns true if the dialog is open.
-     * @return {boolean}
+     * @return
      */
     public isOpen(): boolean {
         return this._isOpen;

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/add-server.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/add-server.component.ts
@@ -60,7 +60,7 @@ export class AddServerDialogComponent {
 
     /**
      * Called to open the dialog.
-     * @param {Oas30Server} server
+     * @param server
      */
     public open(server?: Oas30Server): void {
         if (server) {
@@ -133,7 +133,7 @@ export class AddServerDialogComponent {
 
     /**
      * Returns true if there are any variables to be configured.
-     * @return {boolean}
+     * @return
      */
     public hasVariables(): boolean {
         let rval: boolean = false;
@@ -147,7 +147,7 @@ export class AddServerDialogComponent {
 
     /**
      * Returns the names of the variables.
-     * @return {string[]}
+     * @return
      */
     public variableNames(): string[] {
         let rval: string[] = [];
@@ -190,7 +190,7 @@ export class AddServerDialogComponent {
 
     /**
      * Returns true if the dialog is open.
-     * @return {boolean}
+     * @return
      */
     public isOpen(): boolean {
         return this._isOpen;

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/add-tag.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/add-tag.component.ts
@@ -83,7 +83,7 @@ export class AddTagDialogComponent {
 
     /**
      * Returns true if the dialog is open.
-     * @return {boolean}
+     * @return
      */
     public isOpen(): boolean {
         return this._isOpen;

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/clone-definition.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/clone-definition.component.ts
@@ -44,7 +44,7 @@ export class CloneDefinitionDialogComponent {
 
     /**
      * Called to open the dialog.
-     * @param {Oas20SchemaDefinition | Oas30SchemaDefinition} definition
+     * @param definition
      */
     public open(document: OasDocument, definition: Oas20SchemaDefinition | Oas30SchemaDefinition): void {
         this._isOpen = true;
@@ -110,7 +110,7 @@ export class CloneDefinitionDialogComponent {
 
     /**
      * Returns true if the dialog is open.
-     * @return {boolean}
+     * @return
      */
     public isOpen(): boolean {
         return this._isOpen;

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/clone-path.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/clone-path.component.ts
@@ -44,8 +44,8 @@ export class ClonePathDialogComponent {
 
     /**
      * Called to open the dialog.
-     * @param {OasDocument} document
-     * @param {OasPathItem} path
+     * @param document
+     * @param path
      */
     public open(document: OasDocument, path: OasPathItem): void {
         this.object = path;
@@ -104,7 +104,7 @@ export class ClonePathDialogComponent {
 
     /**
      * Returns true if the dialog is open.
-     * @return {boolean}
+     * @return
      */
     public isOpen(): boolean {
         return this._isOpen;

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/edit-example-20.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/edit-example-20.component.ts
@@ -59,7 +59,7 @@ export class EditExample20DialogComponent {
 
     /**
      * Called to open the dialog.
-     * @param {string} contentType
+     * @param contentType
      * @param value
      */
     public open(contentType: string, value: any): void {
@@ -124,7 +124,7 @@ export class EditExample20DialogComponent {
 
     /**
      * Returns true if the dialog is open.
-     * @return {boolean}
+     * @return
      */
     public isOpen(): boolean {
         return this._isOpen;
@@ -143,7 +143,7 @@ export class EditExample20DialogComponent {
     }
 
     /**
-     * @param {string} value
+     * @param value
      */
     private setValueFormatFromValue(value: string): void {
         if (value && value.trim().startsWith("{")) {

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/edit-example.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/edit-example.component.ts
@@ -58,7 +58,7 @@ export class EditExampleDialogComponent {
 
     /**
      * Called to open the dialog.
-     * @param {Oas30Example} example
+     * @param example
      */
     public open(example: Oas30Example): void {
         this._isOpen = true;
@@ -119,7 +119,7 @@ export class EditExampleDialogComponent {
 
     /**
      * Returns true if the dialog is open.
-     * @return {boolean}
+     * @return
      */
     public isOpen(): boolean {
         return this._isOpen;
@@ -138,7 +138,7 @@ export class EditExampleDialogComponent {
     }
 
     /**
-     * @param {string} value
+     * @param value
      */
     private setValueFormatFromValue(value: string): void {
         if (value && value.trim().startsWith("{")) {

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/rename-definition.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/rename-definition.component.ts
@@ -44,7 +44,7 @@ export class RenameDefinitionDialogComponent {
 
     /**
      * Called to open the dialog.
-     * @param {Oas20SchemaDefinition | Oas30SchemaDefinition} definition
+     * @param definition
      */
     public open(document: OasDocument, definition: Oas20SchemaDefinition | Oas30SchemaDefinition): void {
         this._isOpen = true;
@@ -110,7 +110,7 @@ export class RenameDefinitionDialogComponent {
 
     /**
      * Returns true if the dialog is open.
-     * @return {boolean}
+     * @return
      */
     public isOpen(): boolean {
         return this._isOpen;

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/security-requirement.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/security-requirement.component.ts
@@ -138,7 +138,7 @@ export class SecurityRequirementDialogComponent {
 
     /**
      * Returns true if the dialog is open.
-     * @return {boolean}
+     * @return
      */
     public isOpen(): boolean {
         return this._isOpen;
@@ -146,7 +146,7 @@ export class SecurityRequirementDialogComponent {
 
     /**
      * Returns true if the model is valid.
-     * @return {boolean}
+     * @return
      */
     public isSecurityRequirementValid(): boolean {
         for (let n in this.model) {
@@ -157,8 +157,8 @@ export class SecurityRequirementDialogComponent {
 
     /**
      * Returns true if the given scheme is enabled.
-     * @param {OasSecurityScheme} scheme
-     * @return {boolean}
+     * @param scheme
+     * @return
      */
     public isChecked(scheme: OasSecurityScheme): boolean {
         for (let n in this.model) {
@@ -171,8 +171,8 @@ export class SecurityRequirementDialogComponent {
 
     /**
      * Returns true only if the scheme is one that can be expanded.
-     * @param {OasSecurityScheme} scheme
-     * @return {boolean}
+     * @param scheme
+     * @return
      */
     public canExpand(scheme: OasSecurityScheme): boolean {
         return scheme.type === "oauth2" || scheme.type === "openIdConnect";
@@ -180,8 +180,8 @@ export class SecurityRequirementDialogComponent {
 
     /**
      * Returns true if the given scheme is expanded.
-     * @param {OasSecurityScheme} scheme
-     * @return {boolean}
+     * @param scheme
+     * @return
      */
     public isExpanded(scheme: OasSecurityScheme): boolean {
         return this._expanded[scheme.schemeName()] ? true : false;
@@ -189,7 +189,7 @@ export class SecurityRequirementDialogComponent {
 
     /**
      * Called to toggle the expansion of a scheme.
-     * @param {OasSecurityScheme} scheme
+     * @param scheme
      */
     public toggleExpansion(scheme: OasSecurityScheme): void {
         let pval: boolean = this._expanded[scheme.schemeName()];
@@ -202,7 +202,7 @@ export class SecurityRequirementDialogComponent {
 
     /**
      * Called to expand a scheme.
-     * @param {OasSecurityScheme} scheme
+     * @param scheme
      */
     public expand(scheme: OasSecurityScheme): void {
         this._expanded[scheme.schemeName()] = true;
@@ -210,7 +210,7 @@ export class SecurityRequirementDialogComponent {
 
     /**
      * Called to collapse a scheme.
-     * @param {OasSecurityScheme} scheme
+     * @param scheme
      */
     public collapse(scheme: OasSecurityScheme): void {
         this._expanded[scheme.schemeName()] = false;
@@ -218,7 +218,7 @@ export class SecurityRequirementDialogComponent {
 
     /**
      * Adds/removes the security scheme from the model.
-     * @param {OasSecurityScheme} scheme
+     * @param scheme
      */
     public toggleSecurityScheme(scheme: OasSecurityScheme, enable?: boolean): void {
         if (enable === undefined) {
@@ -239,8 +239,8 @@ export class SecurityRequirementDialogComponent {
 
     /**
      * Returns the possible scopes for the given scheme.
-     * @param {OasSecurityScheme} scheme
-     * @return {ScopeInfo[]}
+     * @param scheme
+     * @return
      */
     public scopes(scheme: OasSecurityScheme): ScopeInfo[] {
         if (this.canExpand(scheme)) {
@@ -258,9 +258,9 @@ export class SecurityRequirementDialogComponent {
 
     /**
      * Returns true if the given scope is enabled/checked in the model.
-     * @param {OasSecurityScheme} scheme
-     * @param {string} scope
-     * @return {boolean}
+     * @param scheme
+     * @param scope
+     * @return
      */
     public isScopeChecked(scheme: OasSecurityScheme, scope: string): boolean {
         let modelScopes: string[] = this.model[scheme.schemeName()];
@@ -272,9 +272,9 @@ export class SecurityRequirementDialogComponent {
 
     /**
      * Toggles the enabled/checked status of a single scope for a given scheme.
-     * @param {OasSecurityScheme} scheme
-     * @param {string} scope
-     * @param {boolean} enable
+     * @param scheme
+     * @param scope
+     * @param enable
      */
     public toggleScope(scheme: OasSecurityScheme, scope: string, enable: boolean): void {
         let modelScopes: string[] = this.model[scheme.schemeName()];
@@ -292,8 +292,8 @@ export class SecurityRequirementDialogComponent {
 
     /**
      * Finds all security schemes defined in the document.
-     * @param {OasDocument} document
-     * @return {OasSecurityScheme[]}
+     * @param document
+     * @return
      */
     public findSchemes(document: OasDocument): OasSecurityScheme[] {
         let visitor: SecuritySchemeFinder = new SecuritySchemeFinder();

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/security-scheme-20.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/security-scheme-20.component.ts
@@ -123,7 +123,7 @@ export class SecurityScheme20DialogComponent {
 
     /**
      * Returns true if the dialog is open.
-     * @return {boolean}
+     * @return
      */
     public isOpen(): boolean {
         return this._isOpen;
@@ -200,7 +200,7 @@ export class SecurityScheme20DialogComponent {
     /**
      * Converts from OAS20 scopes to an array of scope objects.
      * @param scopes
-     * @return {Scope[]}
+     * @return
      */
     private toScopesArray(scopes: Oas20Scopes): Scope[] {
         let rval: Scope[] = [];
@@ -218,7 +218,7 @@ export class SecurityScheme20DialogComponent {
 
     /**
      * Returns true only if all the defined scopes are valid (have names).
-     * @return {boolean}
+     * @return
      */
     public scopesAreValid(): boolean {
         if (this.model.type === "oauth2") {

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/security-scheme-30.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/security-scheme-30.component.ts
@@ -188,7 +188,7 @@ export class SecurityScheme30DialogComponent {
 
     /**
      * Returns true if the dialog is open.
-     * @return {boolean}
+     * @return
      */
     public isOpen(): boolean {
         return this._isOpen;
@@ -204,7 +204,7 @@ export class SecurityScheme30DialogComponent {
 
     /**
      * Called when the user clicks the "Add Scope" button.
-     * @param {string} flow
+     * @param flow
      */
     public addScope(flow: string): void {
         this.model.flows[flow].scopes.push({
@@ -215,8 +215,8 @@ export class SecurityScheme30DialogComponent {
 
     /**
      * Called to delete a scope.
-     * @param {string} flow
-     * @param {Scope} scope
+     * @param flow
+     * @param scope
      */
     public deleteScope(flow: string, scope: Scope): void {
         this.model.flows[flow].scopes.splice(this.model.flows[flow].scopes.indexOf(scope), 1);
@@ -224,7 +224,7 @@ export class SecurityScheme30DialogComponent {
 
     /**
      * Reads the flow information from the security scheme and copies it to the model.
-     * @param {Oas30SecurityScheme} scheme
+     * @param scheme
      */
     private readFlows(scheme: Oas30SecurityScheme) {
         if (!ObjectUtils.isNullOrUndefined(scheme.flows)) {
@@ -245,8 +245,8 @@ export class SecurityScheme30DialogComponent {
 
     /**
      * Reads flow information from the data model into the local UI model.
-     * @param {Oas30OAuthFlow} flowModel
-     * @param {Flow} flow
+     * @param flowModel
+     * @param flow
      */
     private readFlowInto(flowModel: Oas30OAuthFlow, flow: Flow) {
         flow.enabled = true;
@@ -259,7 +259,7 @@ export class SecurityScheme30DialogComponent {
     /**
      * Converts from OAS30 scopes to an array of scope objects.
      * @param scopes
-     * @return {Scope[]}
+     * @return
      */
     private toScopesArray(scopes: any): Scope[] {
         console.info("toScopesArray: %o", scopes);

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/set-contact.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/set-contact.component.ts
@@ -46,7 +46,7 @@ export class SetContactDialogComponent {
 
     /**
      * Called to open the dialog.
-     * @param {OasContact} contact
+     * @param contact
      */
     public open(contact?: OasContact): void {
         this._isOpen = true;
@@ -95,7 +95,7 @@ export class SetContactDialogComponent {
 
     /**
      * Returns true if the dialog is open.
-     * @return {boolean}
+     * @return
      */
     public isOpen(): boolean {
         return this._isOpen;

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/set-license.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/set-license.component.ts
@@ -71,7 +71,7 @@ export class SetLicenseDialogComponent {
 
     /**
      * Returns true if the dialog is open.
-     * @return {boolean}
+     * @return
      */
     public isOpen(): boolean {
         return this._isOpen;

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/main-form.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/main-form.component.ts
@@ -464,6 +464,10 @@ export class Main20FormComponent extends MainFormComponent {
 
     @ViewChild("securityScheme20Dialog") securitySchemeDialog: SecurityScheme20DialogComponent;
 
+    constructor(licenseService: LicenseService) {
+        super(licenseService);
+    }
+
     /**
      * Opens the security scheme dialog.
      * @param scheme
@@ -557,6 +561,10 @@ export class Main20FormComponent extends MainFormComponent {
 export class Main30FormComponent extends MainFormComponent {
 
     @ViewChild("securityScheme30Dialog") securitySchemeDialog: SecurityScheme30DialogComponent;
+
+    constructor(licenseService: LicenseService) {
+        super(licenseService);
+    }
 
     /**
      * Opens the security scheme dialog.

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/main-form.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/main-form.component.ts
@@ -119,7 +119,7 @@ export abstract class MainFormComponent {
 
     /**
      * Returns the current contact object.
-     * @return {OasContact}
+     * @return
      */
     public contact(): OasContact {
         if (this.hasContact()) {
@@ -194,7 +194,7 @@ export abstract class MainFormComponent {
 
     /**
      * Returns the list of tags defined in the document.
-     * @return {OasTag[]}
+     * @return
      */
     public tags(): OasTag[] {
         let tags: OasTag[] = this.document.tags;
@@ -288,7 +288,7 @@ export abstract class MainFormComponent {
 
     /**
      * Returns true if the API has Contact Info defined.
-     * @return {boolean}
+     * @return
      */
     public hasContact(): boolean {
         if (this.document.info && this.document.info.contact) {
@@ -326,7 +326,7 @@ export abstract class MainFormComponent {
 
     /**
      * Returns true if there is at least one security requirement defined.
-     * @return {boolean}
+     * @return
      */
     public hasSecurityRequirements(): boolean {
         return this.securityRequirements().length > 0;
@@ -334,7 +334,7 @@ export abstract class MainFormComponent {
 
     /**
      * Returns true if there is at least one security scheme defined.
-     * @return {boolean}
+     * @return
      */
     public hasSecuritySchemes(): boolean {
         return this.securitySchemes().length > 0;
@@ -342,13 +342,13 @@ export abstract class MainFormComponent {
 
     /**
      * Returns all defined security schemes.
-     * @return {OasSecurityScheme[]}
+     * @return
      */
     public abstract securitySchemes(): OasSecurityScheme[];
 
     /**
      * Returns all defined security requirements.
-     * @return {OasSecurityRequirement[]}
+     * @return
      */
     public securityRequirements(): OasSecurityRequirement[] {
         return this.document.security ? this.document.security : [];
@@ -356,8 +356,8 @@ export abstract class MainFormComponent {
 
     /**
      * Called when the user changes the description of a security scheme in the table of schemes.
-     * @param {OasSecurityScheme} scheme
-     * @param {string} description
+     * @param scheme
+     * @param description
      */
     public changeSecuritySchemeDescription(scheme: OasSecurityScheme, description: string): void {
         let command: ICommand = createChangePropertyCommand<string>(this.document, scheme, "description", description);
@@ -366,13 +366,13 @@ export abstract class MainFormComponent {
 
     /**
      * Called when the user adds a new security scheme.
-     * @param {SecurityScheme20EventData | SecurityScheme30EventData} event
+     * @param event
      */
     public abstract addSecurityScheme(event: SecurityScheme20EventData | SecurityScheme30EventData): void;
 
     /**
      * Called when the user adds a new security requirement.
-     * @param {SecurityRequirementEventData} event
+     * @param event
      */
     public addSecurityRequirement(event: SecurityRequirementEventData): void {
         let requirement: OasSecurityRequirement = this.document.createSecurityRequirement();
@@ -384,13 +384,13 @@ export abstract class MainFormComponent {
 
     /**
      * Called when the user changes an existing security scheme.
-     * @param {SecurityScheme20EventData | SecurityScheme30EventData} event
+     * @param event
      */
     public abstract changeSecurityScheme(event: SecurityScheme20EventData | SecurityScheme30EventData): void;
 
     /**
      * Called when the user changes an existing Security Requirement.
-     * @param {SecurityRequirementEventData} event
+     * @param event
      */
     public changeSecurityRequirement(event: ChangeSecurityRequirementEvent): void {
         let newRequirement: OasSecurityRequirement = this.document.createSecurityRequirement();
@@ -402,7 +402,7 @@ export abstract class MainFormComponent {
 
     /**
      * Deletes a security scheme.
-     * @param {OasSecurityScheme} scheme
+     * @param scheme
      */
     public deleteSecurityScheme(scheme: OasSecurityScheme): void {
         let command: ICommand = createDeleteSecuritySchemeCommand(this.document, scheme.schemeName());
@@ -411,7 +411,7 @@ export abstract class MainFormComponent {
 
     /**
      * Deletes a security requirement.
-     * @param {OasSecurityRequirement} requirement
+     * @param requirement
      */
     public deleteSecurityRequirement(requirement: OasSecurityRequirement): void {
         let command: ICommand = createDeleteSecurityRequirementCommand(this.document, this.document, requirement);
@@ -420,8 +420,8 @@ export abstract class MainFormComponent {
 
     /**
      * Returns a summary of the requirement.
-     * @param {OasSecurityRequirement} requirement
-     * @return {string}
+     * @param requirement
+     * @return
      */
     public securityRequirementSummary(requirement: OasSecurityRequirement): string {
         return requirement.securityRequirementNames().join(", ");
@@ -429,13 +429,13 @@ export abstract class MainFormComponent {
 
     /**
      * Opens the security scheme dialog for adding or editing a security scheme.
-     * @param {OasSecurityScheme} scheme
+     * @param scheme
      */
     public abstract openSecuritySchemeDialog(scheme?: OasSecurityScheme): void;
 
     /**
      * Opens the security requirement dialog for adding or editing a security requirement.
-     * @param {OasSecurityRequirement} requirement
+     * @param requirement
      */
     public openSecurityRequirementDialog(requirement?: OasSecurityRequirement): void {
         this.securityRequirementDialog.open(this.document, requirement);
@@ -443,7 +443,7 @@ export abstract class MainFormComponent {
 
     /**
      * Returns true if the form is for an OpenAPI 3.x document.
-     * @return {boolean}
+     * @return
      */
     public is3xForm(): boolean {
         return false;
@@ -466,7 +466,7 @@ export class Main20FormComponent extends MainFormComponent {
 
     /**
      * Opens the security scheme dialog.
-     * @param {Oas20SecurityScheme} scheme
+     * @param scheme
      */
     public openSecuritySchemeDialog(scheme?: Oas20SecurityScheme): void {
         this.securitySchemeDialog.open(scheme);
@@ -474,7 +474,7 @@ export class Main20FormComponent extends MainFormComponent {
 
     /**
      * Returns all defined security schemes.
-     * @return {OasSecurityScheme[]}
+     * @return
      */
     public securitySchemes(): OasSecurityScheme[] {
         let secdefs: Oas20SecurityDefinitions = (this.document as Oas20Document).securityDefinitions;
@@ -488,7 +488,7 @@ export class Main20FormComponent extends MainFormComponent {
 
     /**
      * Called when the user adds a new security scheme.
-     * @param {SecurityScheme20EventData} event
+     * @param event
      */
     public addSecurityScheme(event: SecurityScheme20EventData): void {
         console.info("[MainFormComponent] Adding a security scheme: %s", event.schemeName);
@@ -517,7 +517,7 @@ export class Main20FormComponent extends MainFormComponent {
 
     /**
      * Called when the user changes an existing security scheme.
-     * @param {SecurityScheme20EventData} event
+     * @param event
      */
     public changeSecurityScheme(event: SecurityScheme20EventData): void {
         console.info("[MainFormComponent] Changing a security scheme: %s", event.schemeName);
@@ -560,7 +560,7 @@ export class Main30FormComponent extends MainFormComponent {
 
     /**
      * Opens the security scheme dialog.
-     * @param {Oas30SecurityScheme} scheme
+     * @param scheme
      */
     public openSecuritySchemeDialog(scheme?: Oas30SecurityScheme): void {
         this.securitySchemeDialog.open(scheme);
@@ -568,7 +568,7 @@ export class Main30FormComponent extends MainFormComponent {
 
     /**
      * Returns all defined security schemes.
-     * @return {OasSecurityScheme[]}
+     * @return
      */
     public securitySchemes(): OasSecurityScheme[] {
         let doc: Oas30Document = this.document as Oas30Document;
@@ -583,7 +583,7 @@ export class Main30FormComponent extends MainFormComponent {
 
     /**
      * Called when the user adds a new security scheme.
-     * @param {SecurityScheme30EventData} event
+     * @param event
      */
     public addSecurityScheme(event: SecurityScheme30EventData): void {
         console.info("[MainFormComponent] Adding a security scheme: %s", event.schemeName);
@@ -597,7 +597,7 @@ export class Main30FormComponent extends MainFormComponent {
 
     /**
      * Called when the user changes an existing security scheme.
-     * @param {SecurityScheme30EventData} event
+     * @param event
      */
     public changeSecurityScheme(event: SecurityScheme30EventData): void {
         console.info("[MainFormComponent] Changing a security scheme: %s", event.schemeName);
@@ -611,7 +611,7 @@ export class Main30FormComponent extends MainFormComponent {
 
     /**
      * Converts from array of scopes to scopes object for data model.
-     * @param {Scope[]} scopes
+     * @param scopes
      */
     private toScopes(scopes: Scope[]): any {
         let rval: any = {};
@@ -623,8 +623,8 @@ export class Main30FormComponent extends MainFormComponent {
 
     /**
      * Copy the event data to the data model.
-     * @param {SecurityScheme30EventData} event
-     * @param {Oas30SecurityScheme} scheme
+     * @param event
+     * @param scheme
      */
     private copySchemeToModel(event: SecurityScheme30EventData, scheme: Oas30SecurityScheme) {
         scheme.description = event.description;
@@ -677,7 +677,7 @@ export class Main30FormComponent extends MainFormComponent {
 
     /**
      * Returns true if the form is for an OpenAPI 3.x document.
-     * @return {boolean}
+     * @return
      */
     public is3xForm(): boolean {
         return true;

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/operation-30-form.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/operation-30-form.component.ts
@@ -421,7 +421,7 @@ export class Operation30FormComponent extends SourceFormComponent<Oas30Operation
 
     /**
      * Returns true if there is at least one security requirement defined.
-     * @return {boolean}
+     * @return
      */
     public hasSecurityRequirements(): boolean {
         return this.securityRequirements().length > 0;
@@ -429,7 +429,7 @@ export class Operation30FormComponent extends SourceFormComponent<Oas30Operation
 
     /**
      * Returns all defined security requirements.
-     * @return {OasSecurityRequirement[]}
+     * @return
      */
     public securityRequirements(): OasSecurityRequirement[] {
         return this.operation.security ? this.operation.security : [];
@@ -437,8 +437,8 @@ export class Operation30FormComponent extends SourceFormComponent<Oas30Operation
 
     /**
      * Returns a summary of the requirement.
-     * @param {OasSecurityRequirement} requirement
-     * @return {string}
+     * @param requirement
+     * @return
      */
     public securityRequirementSummary(requirement: OasSecurityRequirement): string {
         return requirement.securityRequirementNames().join(", ");
@@ -446,7 +446,7 @@ export class Operation30FormComponent extends SourceFormComponent<Oas30Operation
 
     /**
      * Opens the security requirement dialog for adding or editing a security requirement.
-     * @param {OasSecurityRequirement} requirement
+     * @param requirement
      */
     public openSecurityRequirementDialog(requirement?: OasSecurityRequirement): void {
         this.securityRequirementDialog.open(this.operation.ownerDocument(), requirement);
@@ -454,7 +454,7 @@ export class Operation30FormComponent extends SourceFormComponent<Oas30Operation
 
     /**
      * Called when the user adds a new security requirement.
-     * @param {SecurityRequirementEventData} event
+     * @param event
      */
     public addSecurityRequirement(event: SecurityRequirementEventData): void {
         let requirement: OasSecurityRequirement = this.operation.createSecurityRequirement();
@@ -466,7 +466,7 @@ export class Operation30FormComponent extends SourceFormComponent<Oas30Operation
 
     /**
      * Called when the user changes an existing Security Requirement.
-     * @param {SecurityRequirementEventData} event
+     * @param event
      */
     public changeSecurityRequirement(event: ChangeSecurityRequirementEvent): void {
         let newRequirement: OasSecurityRequirement = this.operation.createSecurityRequirement();
@@ -478,7 +478,7 @@ export class Operation30FormComponent extends SourceFormComponent<Oas30Operation
 
     /**
      * Deletes a security requirement.
-     * @param {OasSecurityRequirement} requirement
+     * @param requirement
      */
     public deleteSecurityRequirement(requirement: OasSecurityRequirement): void {
         let command: ICommand = createDeleteSecurityRequirementCommand(this.operation.ownerDocument(), this.operation, requirement);

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/operation-form.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/operation-form.component.ts
@@ -595,7 +595,7 @@ export class OperationFormComponent extends SourceFormComponent<Oas20Operation> 
 
     /**
      * Returns true if there is at least one security requirement defined.
-     * @return {boolean}
+     * @return
      */
     public hasSecurityRequirements(): boolean {
         return this.securityRequirements().length > 0;
@@ -603,7 +603,7 @@ export class OperationFormComponent extends SourceFormComponent<Oas20Operation> 
 
     /**
      * Returns all defined security requirements.
-     * @return {OasSecurityRequirement[]}
+     * @return
      */
     public securityRequirements(): OasSecurityRequirement[] {
         return this.operation.security ? this.operation.security : [];
@@ -611,8 +611,8 @@ export class OperationFormComponent extends SourceFormComponent<Oas20Operation> 
 
     /**
      * Returns a summary of the requirement.
-     * @param {OasSecurityRequirement} requirement
-     * @return {string}
+     * @param requirement
+     * @return
      */
     public securityRequirementSummary(requirement: OasSecurityRequirement): string {
         return requirement.securityRequirementNames().join(", ");
@@ -620,7 +620,7 @@ export class OperationFormComponent extends SourceFormComponent<Oas20Operation> 
 
     /**
      * Opens the security requirement dialog for adding or editing a security requirement.
-     * @param {OasSecurityRequirement} requirement
+     * @param requirement
      */
     public openSecurityRequirementDialog(requirement?: OasSecurityRequirement): void {
         this.securityRequirementDialog.open(this.operation.ownerDocument(), requirement);
@@ -628,7 +628,7 @@ export class OperationFormComponent extends SourceFormComponent<Oas20Operation> 
 
     /**
      * Called when the user adds a new security requirement.
-     * @param {SecurityRequirementEventData} event
+     * @param event
      */
     public addSecurityRequirement(event: SecurityRequirementEventData): void {
         let requirement: OasSecurityRequirement = this.operation.createSecurityRequirement();
@@ -640,7 +640,7 @@ export class OperationFormComponent extends SourceFormComponent<Oas20Operation> 
 
     /**
      * Called when the user changes an existing Security Requirement.
-     * @param {SecurityRequirementEventData} event
+     * @param event
      */
     public changeSecurityRequirement(event: ChangeSecurityRequirementEvent): void {
         let newRequirement: OasSecurityRequirement = this.operation.createSecurityRequirement();
@@ -652,7 +652,7 @@ export class OperationFormComponent extends SourceFormComponent<Oas20Operation> 
 
     /**
      * Deletes a security requirement.
-     * @param {OasSecurityRequirement} requirement
+     * @param requirement
      */
     public deleteSecurityRequirement(requirement: OasSecurityRequirement): void {
         let command: ICommand = createDeleteSecurityRequirementCommand(this.operation.ownerDocument(), this.operation, requirement);

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/path-form.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/path-form.component.ts
@@ -16,7 +16,8 @@
  */
 
 import {Component, EventEmitter, Input, Output, ViewChild, ViewEncapsulation} from "@angular/core";
-import {Oas30PathItem, OasDocument, OasOperation, OasParameterBase, OasPathItem, OasPaths} from "oai-ts-core";
+import {Oas20PathItem, Oas30PathItem, OasDocument, OasOperation, OasParameterBase, OasPathItem, OasPaths} from "oai-ts-core";
+import {ReplaceNodeCommand} from "oai-ts-commands";
 import {SourceFormComponent} from "./source-form.base";
 import {ModelUtils} from "../../_util/model.util";
 import {
@@ -66,7 +67,7 @@ export class PathFormComponent extends SourceFormComponent<OasPathItem> {
         return (<OasPaths>this.path.parent()).createPathItem(this.path.path());
     }
 
-    protected createReplaceNodeCommand(node: OasPathItem) {
+    protected createReplaceNodeCommand(node: OasPathItem): ReplaceNodeCommand<Oas20PathItem> | ReplaceNodeCommand<Oas30PathItem> {
         return createReplacePathItemCommand(this.path.ownerDocument(), this.path as any, node as any);
     }
 

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/servers.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/servers.component.ts
@@ -40,7 +40,7 @@ export class ServersSectionComponent {
 
     /**
      * Returns the list of global servers defined in the document.
-     * @return {Oas30Server[]}
+     * @return
      */
     public servers(): Oas30Server[] {
         let servers: Oas30Server[] = this.parent.servers;
@@ -78,7 +78,7 @@ export class ServersSectionComponent {
 
     /**
      * Called when the user adds a new server.
-     * @param {Server30EventData} event
+     * @param event
      */
     public addServer(event: ServerEventData): void {
         console.info("[MainFormComponent] Adding a server: %s", event.url);
@@ -93,7 +93,7 @@ export class ServersSectionComponent {
 
     /**
      * Called when the user edits an existing server.
-     * @param {ServerEventData} event
+     * @param event
      */
     public changeServer(event: ServerEventData): void {
         console.info("[MainFormComponent] Editing a server: %s", event.url);
@@ -108,8 +108,8 @@ export class ServersSectionComponent {
 
     /**
      * Copies the data from the event to the new server model.
-     * @param {ServerEventData} fromData
-     * @param {Oas30Server} toServer
+     * @param fromData
+     * @param toServer
      */
     private copyServerToModel(fromData: ServerEventData, toServer: Oas30Server): void {
         toServer.url = fromData.url;

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/master.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/master.component.ts
@@ -116,7 +116,7 @@ export class EditorMasterComponent implements OnInit, OnDestroy {
 
     /**
      * Returns an array of paths that match the filter criteria and are sorted alphabetically.
-     * @return {OasPathItem[]}
+     * @return
      */
     public paths(): OasPathItem[] {
         let viz: FindPathItemsVisitor = new FindPathItemsVisitor(this.filterCriteria);
@@ -126,7 +126,7 @@ export class EditorMasterComponent implements OnInit, OnDestroy {
 
     /**
      * Returns the array of definitions, filtered by search criteria and sorted.
-     * @return {(Oas20SchemaDefinition | Oas30SchemaDefinition)[]}
+     * @return
      */
     public definitions(): (Oas20SchemaDefinition | Oas30SchemaDefinition)[] {
         let viz: FindSchemaDefinitionsVisitor = new FindSchemaDefinitionsVisitor(this.filterCriteria);
@@ -136,7 +136,7 @@ export class EditorMasterComponent implements OnInit, OnDestroy {
 
     /**
      * Returns an array of responses filtered by the search criteria and sorted.
-     * @return {(Oas20ResponseDefinition | Oas30ResponseDefinition)[]}
+     * @return
      */
     public responses(): (Oas20ResponseDefinition | Oas30ResponseDefinition)[] {
         return [];
@@ -157,8 +157,8 @@ export class EditorMasterComponent implements OnInit, OnDestroy {
 
     /**
      * Returns true if the given item is a valid path in the current document.
-     * @param {OasPathItem} pathItem
-     * @return {boolean}
+     * @param pathItem
+     * @return
      */
     protected isValidPathItem(pathItem: OasPathItem): boolean {
         if (ObjectUtils.isNullOrUndefined(pathItem)) {
@@ -174,8 +174,8 @@ export class EditorMasterComponent implements OnInit, OnDestroy {
     /**
      * Returns true if the given operation is a valid operation contained within the
      * current document.
-     * @param {OasOperation} operation
-     * @return {boolean}
+     * @param operation
+     * @return
      */
     protected isValidOperation(operation: OasOperation): boolean {
         let pathItem: OasPathItem = operation.parent() as OasPathItem;
@@ -197,8 +197,8 @@ export class EditorMasterComponent implements OnInit, OnDestroy {
     /**
      * Returns true if the given schema definition is valid and contained within the
      * current document.
-     * @param {Oas20SchemaDefinition | Oas30SchemaDefinition} definition
-     * @return {boolean}
+     * @param definition
+     * @return
      */
     protected isValidDefinition(definition: Oas20SchemaDefinition | Oas30SchemaDefinition): boolean {
         if (ObjectUtils.isNullOrUndefined(definition)) {
@@ -210,8 +210,8 @@ export class EditorMasterComponent implements OnInit, OnDestroy {
     /**
      * Returns true if the given response is valid and contained within the
      * current document.
-     * @param {Oas20ResponseDefinition | Oas30ResponseDefinition} response
-     * @return {boolean}
+     * @param response
+     * @return
      */
     protected isValidResponse(response: Oas20ResponseDefinition | Oas30ResponseDefinition): boolean {
         if (ObjectUtils.isNullOrUndefined(response)) {
@@ -229,7 +229,7 @@ export class EditorMasterComponent implements OnInit, OnDestroy {
 
     /**
      * Called when the user selects a path from the master area.
-     * @param {OasPathItem} path
+     * @param path
      */
     public selectPath(path: OasPathItem): void {
         this.selectionService.selectNode(path, this.document);
@@ -290,7 +290,7 @@ export class EditorMasterComponent implements OnInit, OnDestroy {
 
     /**
      * Called when the user selects a response from the master area.
-     * @param {Oas20ResponseDefinition | Oas30ResponseDefinition} response
+     * @param response
      */
     public selectResponse(response: Oas20ResponseDefinition | Oas30ResponseDefinition): void {
         this.selectionService.selectNode(response, this.document);
@@ -332,8 +332,8 @@ export class EditorMasterComponent implements OnInit, OnDestroy {
 
     /**
      * Returns the selection style to use for the given (potentially selected) node.
-     * @param {OasNode} item
-     * @return {string}
+     * @param item
+     * @return
      */
     public collaboratorSelectionClasses(item: OasNode): string {
         if (item) {
@@ -347,7 +347,7 @@ export class EditorMasterComponent implements OnInit, OnDestroy {
 
     /**
      * Called when the user fills out the Add Path modal dialog and clicks Add.
-     * @param {string} path
+     * @param path
      */
     public addPath(path: string): void {
         let command: ICommand = createNewPathCommand(this.document, path);
@@ -357,9 +357,9 @@ export class EditorMasterComponent implements OnInit, OnDestroy {
 
     /**
      * Called to test whether the given resource path has an operation of the given type defined.
-     * @param {OasPathItem} pathItem
-     * @param {string} operation
-     * @return {boolean}
+     * @param pathItem
+     * @param operation
+     * @return
      */
     public hasOperation(pathItem: OasPathItem, operation: string): boolean {
         let op: OasOperation = pathItem[operation];
@@ -369,8 +369,8 @@ export class EditorMasterComponent implements OnInit, OnDestroy {
     /**
      * Returns true if the given node is the currently selected item *or* is the parent
      * of the currently selected item.
-     * @param {OasNode} node
-     * @return {boolean}
+     * @param node
+     * @return
      */
     public isSelected(node: OasNode): boolean {
         return ModelUtils.isSelected(node);
@@ -378,7 +378,7 @@ export class EditorMasterComponent implements OnInit, OnDestroy {
 
     /**
      * Returns true if the main node should be selected.
-     * @return {boolean}
+     * @return
      */
     public isMainSelected(): boolean {
         return ModelUtils.isSelected(this.document);
@@ -386,8 +386,8 @@ export class EditorMasterComponent implements OnInit, OnDestroy {
 
     /**
      * Returns true if the given node is the current context menu item.
-     * @param {OasNode} node
-     * @return {boolean}
+     * @param node
+     * @return
      */
     public isContexted(node: OasNode): boolean {
         if (this.contextMenuSelection === null) {
@@ -398,8 +398,8 @@ export class EditorMasterComponent implements OnInit, OnDestroy {
 
     /**
      * Returns true if the given path item has at least one operation.
-     * @param {OasPathItem} pathItem
-     * @return {boolean}
+     * @param pathItem
+     * @return
      */
     public hasAtLeastOneOperation(pathItem: OasPathItem): boolean {
         if (pathItem) {
@@ -440,8 +440,8 @@ export class EditorMasterComponent implements OnInit, OnDestroy {
 
     /**
      * Gets a definition by its name.
-     * @param {string} name
-     * @return {Oas20SchemaDefinition | Oas30SchemaDefinition}
+     * @param name
+     * @return
      */
     protected getDefinitionByName(name: string): Oas20SchemaDefinition | Oas30SchemaDefinition {
         if (this.document.getSpecVersion() === "2.0") {
@@ -479,8 +479,8 @@ export class EditorMasterComponent implements OnInit, OnDestroy {
 
     /**
      * Called when the user right-clicks on an operation.
-     * @param {MouseEvent} event
-     * @param {OasOperation} operation
+     * @param event
+     * @param operation
      */
     public showOperationContextMenu(event: MouseEvent, operation: OasOperation): void {
         event.preventDefault();
@@ -629,8 +629,8 @@ export class EditorMasterComponent implements OnInit, OnDestroy {
 
     /**
      * Returns the name of the definition.
-     * @param {Oas20SchemaDefinition | Oas30SchemaDefinition} definition
-     * @return {string}
+     * @param definition
+     * @return
      */
     public definitionName(definition: Oas20SchemaDefinition | Oas30SchemaDefinition): string {
         return definition.ownerDocument().getSpecVersion() === "2.0" ?
@@ -651,7 +651,7 @@ export class EditorMasterComponent implements OnInit, OnDestroy {
 
     /**
      * Returns the classes that should be applied to the "main" selection item.
-     * @return {string}
+     * @return
      */
     public mainClasses(): string {
         let classes: string[] = [];
@@ -672,8 +672,8 @@ export class EditorMasterComponent implements OnInit, OnDestroy {
 
     /**
      * Returns the classes that should be applied to the path item in the master view.
-     * @param {OasPathItem} node
-     * @return {string}
+     * @param node
+     * @return
      */
     public pathClasses(node: OasPathItem): string {
         let classes: string[] = [];
@@ -691,8 +691,8 @@ export class EditorMasterComponent implements OnInit, OnDestroy {
 
     /**
      * Returns the classes that should be applied to the operation in the master view.
-     * @param {OasOperation} node
-     * @return {string}
+     * @param node
+     * @return
      */
     public operationClasses(node: OasOperation): string {
         let classes: string[] = [];
@@ -710,8 +710,8 @@ export class EditorMasterComponent implements OnInit, OnDestroy {
 
     /**
      * Returns the classes that should be applied to the validation problem.
-     * @param {OasValidationProblem} node
-     * @return {string}
+     * @param node
+     * @return
      */
     public problemClasses(node: OasValidationProblem): string {
         let classes: string[] = [];
@@ -726,8 +726,8 @@ export class EditorMasterComponent implements OnInit, OnDestroy {
 
     /**
      * Returns the classes that should be applied to the schema definition in the master view.
-     * @param {OasNode} node
-     * @return {string}
+     * @param node
+     * @return
      */
     public definitionClasses(node: OasNode): string {
         let classes: string[] = [];

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_services/httpcode.service.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_services/httpcode.service.ts
@@ -100,7 +100,7 @@ export class HttpCodeService {
     /**
      * Resolves a single code (returns the HttpCode object for a given response code).
      * @param code
-     * @return {any}
+     * @return
      */
     public getCode(code: string): HttpCode {
         for (let c of this.getCodes()) {

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_services/license.service.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_services/license.service.ts
@@ -266,7 +266,7 @@ export class LicenseService {
 
     /**
      * Returns a list of all licenses.
-     * @return {({id: string, name: string, description: string, url: string, moreInfoUrl: string, permissions: (string|string|string|string|string)[], conditions: (string|string|string|string|string)[], limitations: (string|string)[]}|{id: string, name: string, description: string, url: string, moreInfoUrl: string, permissions: (string|string|string|string|string)[], conditions: (string|string|string|string)[], limitations: (string|string)[]}|{id: string, name: string, description: string, url: string, moreInfoUrl: string, permissions: (string|string|string|string|string)[], conditions: (string|string|string|string)[], limitations: (string|string)[]}|{id: string, name: string, description: string, url: string, moreInfoUrl: string, permissions: (string|string|string|string|string)[], conditions: (string|string|string)[], limitations: (string|string|string)[]}|{id: string, name: string, description: string, url: string, moreInfoUrl: string, permissions: (string|string|string|string|string)[], conditions: (string|string)[], limitations: (string|string|string)[]}|{id: string, name: string, description: string, url: string, moreInfoUrl: string, permissions: (string|string|string|string)[], conditions: string[], limitations: (string|string)[]}|{id: string, name: string, description: string, url: string, moreInfoUrl: string, permissions: (string|string|string|string)[], conditions: Array, limitations: (string|string)[]})[]}
+     * @return|{id: string, name: string, description: string, url: string, moreInfoUrl: string, permissions: (string|string|string|string|string)[], conditions: (string|string|string|string)[], limitations: (string|string)[]}|{id: string, name: string, description: string, url: string, moreInfoUrl: string, permissions: (string|string|string|string|string)[], conditions: (string|string|string|string)[], limitations: (string|string)[]}|{id: string, name: string, description: string, url: string, moreInfoUrl: string, permissions: (string|string|string|string|string)[], conditions: (string|string|string)[], limitations: (string|string|string)[]}|{id: string, name: string, description: string, url: string, moreInfoUrl: string, permissions: (string|string|string|string|string)[], conditions: (string|string)[], limitations: (string|string|string)[]}|{id: string, name: string, description: string, url: string, moreInfoUrl: string, permissions: (string|string|string|string)[], conditions: string[], limitations: (string|string)[]}|{id: string, name: string, description: string, url: string, moreInfoUrl: string, permissions: (string|string|string|string)[], conditions: Array, limitations: (string|string)[]})[]}
      */
     public getLicenses(): ILicense[] {
         return LICENSE_DATA;
@@ -324,7 +324,7 @@ export class LicenseService {
      * Finds a license by its URL.  Multiple URLs may resolve to the same
      * license.
      * @param url
-     * @return {any}
+     * @return
      */
     public findLicense(url: string): ILicense {
         for (let license of LICENSE_DATA) {

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_services/selection.service.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_services/selection.service.ts
@@ -79,9 +79,9 @@ class CollaboratorSelections {
 
     /**
      * Sets the selection for a given active collaborator.  Returns the user's previous selection.
-     * @param {ApiEditorUser} user
-     * @param {string} selection
-     * @return {OasNode}
+     * @param user
+     * @param selection
+     * @return
      */
     public setSelection(user: ApiEditorUser, selection: string, document: OasDocument): void {
         // First, clear any previous selection the user may have had.

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_util/model.util.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_util/model.util.ts
@@ -26,7 +26,7 @@ export class ModelUtils {
      * string "/resources/{fooId}/subresources/{barId}" is passed in, the following
      * string array will be returned:  [ "fooId", "barId" ]
      * @param path
-     * @return {string[]}
+     * @return
      */
     public static detectPathParamNames(path: string): string[] {
         let segments: string[] = path.split("/");
@@ -45,7 +45,7 @@ export class ModelUtils {
      * for a given path.
      * @param path
      * @param paramName
-     * @return {Oas20Parameter[]}
+     * @return
      */
     public static getAllPathParams(path: Oas20PathItem, paramName: string): Oas20Parameter[] {
         let operations: OasOperation[] = [
@@ -68,7 +68,7 @@ export class ModelUtils {
 
     /**
      * Clears any possible selection that may exist on the given node for the local user.
-     * @param {OasNode} node
+     * @param node
      */
     public static clearSelection(node: OasNode): void {
         node.n_attribute("local-selection", false);
@@ -77,7 +77,7 @@ export class ModelUtils {
     /**
      * Sets the local selection on the node.  Essentially this marks the node as "selected"
      * for the local user.
-     * @param {OasNode} node
+     * @param node
      */
     public static setSelection(node: OasNode): void {
         node.n_attribute("local-selection", true);
@@ -85,8 +85,8 @@ export class ModelUtils {
 
     /**
      * Checks whether the given item is selected by the local user.
-     * @param {OasNode} node
-     * @return {ApiEditorUser}
+     * @param node
+     * @return
      */
     public static isSelected(node: OasNode): boolean {
         let rval: boolean = node.n_attribute("local-selection");
@@ -98,8 +98,8 @@ export class ModelUtils {
 
     /**
      * Clears any possible selection that may exist on the given node for the given user.
-     * @param {ApiEditorUser} user
-     * @param {OasNode} node
+     * @param user
+     * @param node
      */
     public static clearCollaboratorSelection(user: ApiEditorUser, node: OasNode): void {
         let selections: any = node.n_attribute("collaborator-selections");
@@ -111,8 +111,8 @@ export class ModelUtils {
     /**
      * Sets the collaborator selection for the given user on the node.  Essentially this marks
      * the node as "selected" by the external (active) collaborator.
-     * @param {ApiEditorUser} user
-     * @param {OasNode} node
+     * @param user
+     * @param node
      */
     public static setCollaboratorSelection(user: ApiEditorUser, node: OasNode): void {
         let selections: any = node.n_attribute("collaborator-selections");
@@ -126,8 +126,8 @@ export class ModelUtils {
     /**
      * Checks whether the given item is selected by an external collaborator.  Returns the collaborator
      * information if the item is selected or else null.
-     * @param {OasNode} node
-     * @return {ApiEditorUser}
+     * @param node
+     * @return
      */
     public static isSelectedByCollaborator(node: OasNode): ApiEditorUser {
         let selections: any = node.n_attribute("collaborator-selections");

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_util/object.util.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_util/object.util.ts
@@ -39,7 +39,7 @@ export class ArrayUtils {
      * Returns true if the given item is contained in the given array.
      * @param a
      * @param item
-     * @return {boolean}
+     * @return
      */
     public static contains(a: any[], item: any): boolean {
         for (let aitem of a) {

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_visitors/path-items.visitor.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_visitors/path-items.visitor.ts
@@ -25,7 +25,7 @@ export class FindPathItemsVisitor extends OasCombinedVisitorAdapter {
 
     /**
      * C'tor.
-     * @param {string} filterCriteria
+     * @param filterCriteria
      */
     constructor(private filterCriteria: string) {
         super();
@@ -33,7 +33,7 @@ export class FindPathItemsVisitor extends OasCombinedVisitorAdapter {
 
     /**
      * Called when a path item is visited.
-     * @param {OasPathItem} node
+     * @param node
      */
     visitPathItem(node: OasPathItem): void {
         if (this.acceptThroughFilter(node.path())) {
@@ -53,7 +53,7 @@ export class FindPathItemsVisitor extends OasCombinedVisitorAdapter {
     /**
      * Returns true if the given name is accepted by the current filter criteria.
      * @param name
-     * @return {boolean}
+     * @return
      */
     private acceptThroughFilter(name: string): boolean {
         if (this.filterCriteria === null) {

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_visitors/schema-definitions.visitor.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_visitors/schema-definitions.visitor.ts
@@ -25,7 +25,7 @@ export class FindSchemaDefinitionsVisitor extends OasCombinedVisitorAdapter {
 
     /**
      * C'tor.
-     * @param {string} filterCriteria
+     * @param filterCriteria
      */
     constructor(private filterCriteria: string) {
         super();
@@ -33,7 +33,7 @@ export class FindSchemaDefinitionsVisitor extends OasCombinedVisitorAdapter {
 
     /**
      * Called when a schema definition is visited.
-     * @param {Oas20SchemaDefinition | Oas30SchemaDefinition} node
+     * @param node
      */
     visitSchemaDefinition(node: Oas20SchemaDefinition | Oas30SchemaDefinition): void {
         let name: string = FindSchemaDefinitionsVisitor.definitionName(node);
@@ -55,8 +55,8 @@ export class FindSchemaDefinitionsVisitor extends OasCombinedVisitorAdapter {
 
     /**
      * Figures out the definition name regardless of the version of the model.
-     * @param {Oas20SchemaDefinition | Oas30SchemaDefinition} definition
-     * @return {string}
+     * @param definition
+     * @return
      */
     public static definitionName(definition: Oas20SchemaDefinition|Oas30SchemaDefinition): string {
         let name: string;
@@ -71,7 +71,7 @@ export class FindSchemaDefinitionsVisitor extends OasCombinedVisitorAdapter {
     /**
      * Returns true if the given name is accepted by the current filter criteria.
      * @param name
-     * @return {boolean}
+     * @return
      */
     private acceptThroughFilter(name: string): boolean {
         //console.info("Accepting: %s through filter: %s", name, this.filterCriteria);

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/editor.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/editor.component.ts
@@ -97,7 +97,7 @@ export class ApiEditorComponent implements OnChanges, OnInit, OnDestroy {
 
     /**
      * Called when the @Input changes.
-     * @param {SimpleChanges} changes
+     * @param changes
      */
     ngOnChanges(changes: SimpleChanges): void {
         this._document = null;
@@ -126,7 +126,7 @@ export class ApiEditorComponent implements OnChanges, OnInit, OnDestroy {
 
     /**
      * Lazy getter for the OtEngine.
-     * @return {OtEngine}
+     * @return
      */
     public otEngine(): OtEngine {
         if (this._otEngine === null) {
@@ -177,7 +177,7 @@ export class ApiEditorComponent implements OnChanges, OnInit, OnDestroy {
      * Executes a command.  Called by the parent of this component when detecting that
      * another user has executed a command.  In other words, this command is *not*
      * performed by the local user.
-     * @param {ICommand} command
+     * @param command
      */
     public executeCommand(command: OtCommand): void {
         console.info("[ApiEditorComponent] Executing a command.");
@@ -192,7 +192,7 @@ export class ApiEditorComponent implements OnChanges, OnInit, OnDestroy {
 
     /**
      * Finalizes a command.
-     * @param {ApiDesignCommandAck} ack
+     * @param ack
      */
     public finalizeCommand(ack: ApiDesignCommandAck): void {
         this.otEngine().finalizeCommand(ack.commandId, ack.contentVersion);
@@ -200,8 +200,8 @@ export class ApiEditorComponent implements OnChanges, OnInit, OnDestroy {
 
     /**
      * Called to update the selection state of the given remote API editor (i.e. an active collaborator).
-     * @param {ApiEditorUser} user
-     * @param {string} selection
+     * @param user
+     * @param selection
      */
     public updateCollaboratorSelection(user: ApiEditorUser, selection: string): void {
         this.selectionService.setCollaboratorSelection(user, selection, this.document());
@@ -209,7 +209,7 @@ export class ApiEditorComponent implements OnChanges, OnInit, OnDestroy {
 
     /**
      * Called when the user selects a node in some way.
-     * @param {OasNodePath} path
+     * @param path
      */
     public onNodeSelected(path: OasNodePath): void {
         console.info("[ApiEditorComponent] Selection changed to path: %s", path.toString());
@@ -235,7 +235,7 @@ export class ApiEditorComponent implements OnChanges, OnInit, OnDestroy {
 
     /**
      * Returns the currently selected path item.
-     * @return {OasPathItem}
+     * @return
      */
     public selectedPath(): OasPathItem {
         if (this.currentSelectionType === "path") {
@@ -258,7 +258,7 @@ export class ApiEditorComponent implements OnChanges, OnInit, OnDestroy {
 
     /**
      * Returns the currently selected definition.
-     * @return {Oas20SchemaDefinition}
+     * @return
      */
     public selectedDefinition(): Oas20SchemaDefinition | Oas30SchemaDefinition {
         if (this.currentSelectionType === "definition") {
@@ -270,7 +270,7 @@ export class ApiEditorComponent implements OnChanges, OnInit, OnDestroy {
 
     /**
      * Returns the currently selected definition.
-     * @return {OasValidationProblem}
+     * @return
      */
     public selectedProblem(): OasValidationProblem {
         if (this.currentSelectionType === "problem") {

--- a/front-end/studio/src/app/util/common.ts
+++ b/front-end/studio/src/app/util/common.ts
@@ -37,7 +37,7 @@ export class ArrayUtils {
      * Returns true if the given item is contained in the given array.
      * @param a
      * @param item
-     * @return {boolean}
+     * @return
      */
     public static contains(a: any[], item: any): boolean {
         for (let aitem of a) {

--- a/front-end/studio/yarn.lock
+++ b/front-end/studio/yarn.lock
@@ -28,8 +28,8 @@
     rxjs "^5.5.6"
 
 "@angular/animations@^5.2.0":
-  version "5.2.5"
-  resolved "https://registry.yarnpkg.com/@angular/animations/-/animations-5.2.5.tgz#3e72184321c4979305619c74902b8be92d76db70"
+  version "5.2.11"
+  resolved "https://registry.yarnpkg.com/@angular/animations/-/animations-5.2.11.tgz#2bd3fe9e72916ca28de9bfaaddf0cb936565a0b8"
   dependencies:
     tslib "^1.7.1"
 
@@ -97,8 +97,8 @@
     node-sass "^4.7.2"
 
 "@angular/common@^5.2.0":
-  version "5.2.5"
-  resolved "https://registry.yarnpkg.com/@angular/common/-/common-5.2.5.tgz#08dd636fa46077d047066b13a1aae494066f6c55"
+  version "5.2.11"
+  resolved "https://registry.yarnpkg.com/@angular/common/-/common-5.2.11.tgz#ee7520b02510a2868f30b1f91897102d48324edf"
   dependencies:
     tslib "^1.7.1"
 
@@ -112,20 +112,20 @@
     tsickle "^0.26.0"
 
 "@angular/compiler@^5.2.0":
-  version "5.2.5"
-  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-5.2.5.tgz#5e3b511906048a579fcd007aba72911472e5aa28"
+  version "5.2.11"
+  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-5.2.11.tgz#ca2c38cda6ddde52b5948b8cff6551ff19d5e9de"
   dependencies:
     tslib "^1.7.1"
 
 "@angular/core@^5.2.0":
-  version "5.2.5"
-  resolved "https://registry.yarnpkg.com/@angular/core/-/core-5.2.5.tgz#24f9cd75c5b2728f2ddd1869777590ea7177bca9"
+  version "5.2.11"
+  resolved "https://registry.yarnpkg.com/@angular/core/-/core-5.2.11.tgz#0e38fdf4fa038a3c168c72952682f2ee3721f1a3"
   dependencies:
     tslib "^1.7.1"
 
 "@angular/forms@^5.2.0":
-  version "5.2.5"
-  resolved "https://registry.yarnpkg.com/@angular/forms/-/forms-5.2.5.tgz#2ad7a420c6ef6cd87a34071c5319ec83f7ed56aa"
+  version "5.2.11"
+  resolved "https://registry.yarnpkg.com/@angular/forms/-/forms-5.2.11.tgz#712534fa317e194caa452d0c1a8efc72f5e040d6"
   dependencies:
     tslib "^1.7.1"
 
@@ -134,20 +134,20 @@
   resolved "https://registry.yarnpkg.com/@angular/language-service/-/language-service-5.2.5.tgz#7c3021f347dd4b28ae0a867700894f3de4930f48"
 
 "@angular/platform-browser-dynamic@^5.2.0":
-  version "5.2.5"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-5.2.5.tgz#b89df410bd953e2a6843325f9ac3c09a10eadaf0"
+  version "5.2.11"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-5.2.11.tgz#1b2a9de4af207bee7040400f61c01a44e929c308"
   dependencies:
     tslib "^1.7.1"
 
 "@angular/platform-browser@^5.2.0":
-  version "5.2.5"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-5.2.5.tgz#eae4af2b742fb901d84d6367cd99f9e88102151f"
+  version "5.2.11"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-5.2.11.tgz#5be379f96d74b4ebe84a447633ed5279cb7e641e"
   dependencies:
     tslib "^1.7.1"
 
 "@angular/router@^5.2.0":
-  version "5.2.5"
-  resolved "https://registry.yarnpkg.com/@angular/router/-/router-5.2.5.tgz#f8f220d5fb85fc10d60fe606b0f2a64732265142"
+  version "5.2.11"
+  resolved "https://registry.yarnpkg.com/@angular/router/-/router-5.2.11.tgz#65a902daea923086ec728817c43d87becd99d7a7"
   dependencies:
     tslib "^1.7.1"
 
@@ -203,13 +203,17 @@ acorn-dynamic-import@^2.0.0:
   dependencies:
     acorn "^4.0.3"
 
-acorn@^4.0.3:
+acorn@4.x, acorn@^4.0.3:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
 acorn@^5.0.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.4.1.tgz#fdc58d9d17f4a4e98d102ded826a9b9759125102"
+
+acorn@^5.2.1:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
 
 ajv-keywords@^2.0.0:
   version "2.1.1"
@@ -259,6 +263,12 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
+ansi-align@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f"
+  dependencies:
+    string-width "^2.0.0"
+
 ansi-html@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
@@ -278,6 +288,12 @@ ansi-styles@^2.2.1:
 ansi-styles@^3.1.0, ansi-styles@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
+  dependencies:
+    color-convert "^1.9.0"
+
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   dependencies:
     color-convert "^1.9.0"
 
@@ -330,6 +346,10 @@ arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
 
+array-filter@~0.0.0:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-0.0.1.tgz#7da8cf2e26628ed732803581fd21f67cacd2eeec"
+
 array-find-index@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
@@ -348,6 +368,14 @@ array-includes@^3.0.3:
   dependencies:
     define-properties "^1.1.2"
     es-abstract "^1.7.0"
+
+array-map@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/array-map/-/array-map-0.0.0.tgz#88a2bab73d1cf7bcd5c1b118a003f66f665fa662"
+
+array-reduce@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/array-reduce/-/array-reduce-0.0.0.tgz#173899d3ffd1c7d9383e4479525dbe278cab5f2b"
 
 array-union@^1.0.1:
   version "1.0.2"
@@ -442,7 +470,7 @@ autoprefixer@^6.3.1:
     postcss "^5.2.16"
     postcss-value-parser "^3.2.3"
 
-autoprefixer@^7.2.3:
+autoprefixer@^7.1.1, autoprefixer@^7.2.3:
   version "7.2.6"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-7.2.6.tgz#256672f86f7c735da849c4f07d008abb056067dc"
   dependencies:
@@ -492,7 +520,7 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-runtime@^6.22.0, babel-runtime@^6.26.0:
+babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@^6.9.2:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -641,8 +669,8 @@ boom@5.x.x:
     hoek "4.x.x"
 
 bootstrap-datepicker@^1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/bootstrap-datepicker/-/bootstrap-datepicker-1.7.1.tgz#4ee7faf34888dbec7834fbf9dbe7c4277e01ddaf"
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/bootstrap-datepicker/-/bootstrap-datepicker-1.8.0.tgz#c63513931e6f09f16ae9f11b62f32d950df3958e"
   dependencies:
     jquery ">=1.7.1 <4.0.0"
 
@@ -651,10 +679,8 @@ bootstrap-sass@^3.3.7:
   resolved "https://registry.yarnpkg.com/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz#6596c7ab40f6637393323ab0bc80d064fc630498"
 
 bootstrap-select@^1.12.2:
-  version "1.12.4"
-  resolved "https://registry.yarnpkg.com/bootstrap-select/-/bootstrap-select-1.12.4.tgz#7f15d3c0ce978868d9c09c70f96624f55fa02ee1"
-  dependencies:
-    jquery ">=1.8"
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/bootstrap-select/-/bootstrap-select-1.13.1.tgz#f59c02926fb5ac6356b9d1cdbc5384c2f013d9ba"
 
 bootstrap-slider@^9.9.0:
   version "9.10.0"
@@ -671,6 +697,18 @@ bootstrap-touchspin@~3.1.1:
 bootstrap@3.3.x, bootstrap@^3.3, bootstrap@~3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.3.7.tgz#5a389394549f23330875a3b150656574f8a9eb71"
+
+boxen@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/boxen/-/boxen-1.3.0.tgz#55c6c39a8ba58d9c61ad22cd877532deb665a20b"
+  dependencies:
+    ansi-align "^2.0.0"
+    camelcase "^4.0.0"
+    chalk "^2.0.1"
+    cli-boxes "^1.0.0"
+    string-width "^2.0.0"
+    term-size "^1.2.0"
+    widest-line "^2.0.0"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -770,12 +808,16 @@ browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
     caniuse-db "^1.0.30000639"
     electron-to-chromium "^1.2.7"
 
-browserslist@^2.11.3:
+browserslist@^2.1.5, browserslist@^2.11.3:
   version "2.11.3"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.11.3.tgz#fe36167aed1bbcde4827ebfe71347a2cc70b99b2"
   dependencies:
     caniuse-lite "^1.0.30000792"
     electron-to-chromium "^1.3.30"
+
+buffer-crc32@^0.2.5:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
 
 buffer-indexof@^1.0.0:
   version "1.1.1"
@@ -797,6 +839,10 @@ builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
+builtin-modules@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-2.0.0.tgz#60b7ef5ae6546bd7deefa74b08b62a43a232648e"
+
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
@@ -806,8 +852,8 @@ bytes@3.0.0:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
 
 c3@~0.4.11:
-  version "0.4.21"
-  resolved "https://registry.yarnpkg.com/c3/-/c3-0.4.21.tgz#61a2dc5a31c6a64e011d15b136c160c44fbb9631"
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/c3/-/c3-0.4.23.tgz#32ece135d0ac6d124187be5c6935903699643002"
   dependencies:
     d3 "~3.5.0"
 
@@ -869,7 +915,7 @@ camelcase@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
 
-camelcase@^4.1.0:
+camelcase@^4.0.0, camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
@@ -889,6 +935,10 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
 caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805:
   version "1.0.30000808"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000808.tgz#7d759b5518529ea08b6705a19e70dbf401628ffc"
+
+capture-stack-trace@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz#4a6fa07399c26bba47f0b2496b4d0fb408c5550d"
 
 caseless@~0.11.0:
   version "0.11.0"
@@ -923,6 +973,14 @@ chalk@^2.0.0, chalk@^2.3.0, chalk@^2.3.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.2.0"
 
+chalk@^2.0.1, chalk@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 chalk@~2.2.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.2.2.tgz#4403f5cf18f35c05f51fbdf152bf588f956cf7cb"
@@ -931,7 +989,7 @@ chalk@~2.2.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
-chokidar@^1.4.2, chokidar@^1.7.0:
+chokidar@^1.4.2, chokidar@^1.6.0, chokidar@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
   dependencies:
@@ -968,6 +1026,10 @@ chownr@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
 
+ci-info@^1.0.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.3.tgz#710193264bb05c77b8c90d02f5aaf22216a667b2"
+
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
@@ -999,6 +1061,16 @@ clean-css@4.1.x:
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.9.tgz#35cee8ae7687a49b98034f70de00c4edd3826301"
   dependencies:
     source-map "0.5.x"
+
+clean-css@^4.x:
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.11.tgz#2ecdf145aba38f54740f26cefd0ff3e03e125d6a"
+  dependencies:
+    source-map "0.5.x"
+
+cli-boxes@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
 
 cliui@^2.1.0:
   version "2.1.0"
@@ -1100,9 +1172,17 @@ commander@2.14.x, commander@^2.9.0, commander@~2.14.1:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.14.1.tgz#2235123e37af8ca3c65df45b026dbd357b01b9aa"
 
+commander@^2.12.0, commander@~2.15.0:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
+
 commander@~2.13.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
+
+commenting@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/commenting/-/commenting-1.0.5.tgz#3104d542cac8a4f27b3d51438f4b80431fe4526b"
 
 common-tags@^1.3.1:
   version "1.7.2"
@@ -1147,6 +1227,17 @@ concat-stream@^1.5.0:
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
+
+configstore@^3.0.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/configstore/-/configstore-3.1.2.tgz#c6f25defaeef26df12dd33414b001fe81a543f8f"
+  dependencies:
+    dot-prop "^4.1.0"
+    graceful-fs "^4.1.2"
+    make-dir "^1.0.0"
+    unique-string "^1.0.0"
+    write-file-atomic "^2.0.0"
+    xdg-basedir "^3.0.0"
 
 connect-history-api-fallback@^1.3.0:
   version "1.5.0"
@@ -1218,9 +1309,13 @@ core-js@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
 
-core-js@^2.4.0, core-js@^2.4.1:
+core-js@^2.4.0:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
+
+core-js@^2.4.1:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.6.tgz#0fe6d45bf3cac3ac364a9d72de7576f4eb221b9d"
 
 core-object@^3.1.0:
   version "3.1.5"
@@ -1244,12 +1339,34 @@ cosmiconfig@^2.1.0, cosmiconfig@^2.1.1:
     parse-json "^2.2.0"
     require-from-string "^1.1.0"
 
+cpx@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/cpx/-/cpx-1.5.0.tgz#185be018511d87270dedccc293171e37655ab88f"
+  dependencies:
+    babel-runtime "^6.9.2"
+    chokidar "^1.6.0"
+    duplexer "^0.1.1"
+    glob "^7.0.5"
+    glob2base "^0.0.12"
+    minimatch "^3.0.2"
+    mkdirp "^0.5.1"
+    resolve "^1.1.7"
+    safe-buffer "^5.0.1"
+    shell-quote "^1.6.1"
+    subarg "^1.0.0"
+
 create-ecdh@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.0.tgz#888c723596cdf7612f6498233eebd7a35301737d"
   dependencies:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
+
+create-error-class@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
+  dependencies:
+    capture-stack-trace "^1.0.0"
 
 create-hash@^1.1.0, create-hash@^1.1.2:
   version "1.1.3"
@@ -1313,6 +1430,10 @@ crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
+
+crypto-random-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
 
 css-color-names@0.0.4:
   version "0.0.4"
@@ -1503,6 +1624,10 @@ deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
+deep-extend@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.5.1.tgz#b894a9dd90d3023fbf1c55a394fb858eb2066f1f"
+
 deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
@@ -1666,11 +1791,25 @@ domutils@1.5.1:
     dom-serializer "0"
     domelementtype "1"
 
+dot-prop@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
+  dependencies:
+    is-obj "^1.0.0"
+
 drmonty-datatables-colvis@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/drmonty-datatables-colvis/-/drmonty-datatables-colvis-1.1.2.tgz#96ab9edfb48643cc2edda3f87b88933cdee8127c"
   dependencies:
     jquery ">=1.7.0"
+
+duplexer3@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
+
+duplexer@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
 
 duplexify@^3.4.2, duplexify@^3.5.3:
   version "3.5.3"
@@ -1757,7 +1896,7 @@ errno@^0.1.1, errno@^0.1.3, errno@^0.1.4:
   dependencies:
     prr "~1.0.1"
 
-error-ex@^1.2.0:
+error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
   dependencies:
@@ -1806,6 +1945,10 @@ es6-map@^0.1.3:
     es6-set "~0.1.5"
     es6-symbol "~3.1.1"
     event-emitter "~0.3.5"
+
+es6-promise@^3.1.2:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.3.1.tgz#a08cdde84ccdbf34d027a1451bc91d4bcd28a613"
 
 es6-set@~0.1.5:
   version "0.1.5"
@@ -1868,6 +2011,10 @@ esrecurse@^4.1.0:
 estraverse@^4.1.0, estraverse@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
+
+estree-walker@^0.5.0, estree-walker@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.5.2.tgz#d3850be7529c9580d815600b53126515e146dd39"
 
 esutils@^2.0.2:
   version "2.0.2"
@@ -2110,6 +2257,14 @@ find-cache-dir@^1.0.0:
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
 
+find-index@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/find-index/-/find-index-0.1.1.tgz#675d358b2ca3892d795a1ab47232f8b6e2e0dde4"
+
+find-parent-dir@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
+
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -2214,6 +2369,20 @@ fs-extra@^4.0.0:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
+
+fs-extra@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-minipass@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
+  dependencies:
+    minipass "^2.2.1"
 
 fs-write-stream-atomic@^1.0.8:
   version "1.0.10"
@@ -2327,6 +2496,12 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
+glob2base@^0.0.12:
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/glob2base/-/glob2base-0.0.12.tgz#9d419b3e28f12e83a362164a277055922c9c0d56"
+  dependencies:
+    find-index "^0.1.1"
+
 glob@7.0.x:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.6.tgz#211bafaf49e525b8cd93260d14ab136152b3f57a"
@@ -2358,6 +2533,12 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.2, glob@~7.1.1:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+global-dirs@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.1.tgz#b319c0dd4607f353f3be9cca4c72fc148c49f445"
+  dependencies:
+    ini "^1.3.4"
 
 globals@^9.18.0:
   version "9.18.0"
@@ -2396,7 +2577,23 @@ google-code-prettify@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/google-code-prettify/-/google-code-prettify-1.0.5.tgz#9f477f224dbfa62372e5ef803a7e157410400084"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
+got@^6.7.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
+  dependencies:
+    create-error-class "^3.0.0"
+    duplexer3 "^0.1.4"
+    get-stream "^3.0.0"
+    is-redirect "^1.0.0"
+    is-retry-allowed "^1.0.0"
+    is-stream "^1.0.0"
+    lowercase-keys "^1.0.0"
+    safe-buffer "^5.0.1"
+    timed-out "^4.0.0"
+    unzip-response "^2.0.1"
+    url-parse-lax "^1.0.0"
+
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -2691,6 +2888,10 @@ image-size@~0.5.0:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
 
+import-lazy@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
+
 import-local@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"
@@ -2735,9 +2936,13 @@ inherits@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
 
-ini@~1.3.0:
+ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
+
+injection-js@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/injection-js/-/injection-js-2.2.1.tgz#a8d6a085b2f0b8d8650f6f4487f6abb8cc0d67ce"
 
 internal-ip@1.2.0:
   version "1.2.0"
@@ -2806,6 +3011,12 @@ is-builtin-module@^1.0.0:
 is-callable@^1.1.1, is-callable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
+
+is-ci@^1.0.10:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.1.0.tgz#247e4162e7860cebbdaf30b774d6b0ac7dcfe7a5"
+  dependencies:
+    ci-info "^1.0.0"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -2905,6 +3116,17 @@ is-glob@^4.0.0:
   dependencies:
     is-extglob "^2.1.1"
 
+is-installed-globally@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.1.0.tgz#0dfd98f5a9111716dd535dda6492f67bf3d25a80"
+  dependencies:
+    global-dirs "^0.1.0"
+    is-path-inside "^1.0.0"
+
+is-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
+
 is-my-ip-valid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz#7b351b8e8edd4d3995d4d066680e664d94696824"
@@ -2919,6 +3141,10 @@ is-my-json-valid@^2.12.4:
     jsonpointer "^4.0.0"
     xtend "^4.0.0"
 
+is-npm@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
+
 is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
@@ -2930,6 +3156,10 @@ is-number@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
   dependencies:
     kind-of "^3.0.2"
+
+is-obj@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
 
 is-odd@^1.0.0:
   version "1.0.0"
@@ -2975,13 +3205,21 @@ is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
 
+is-redirect@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
+
 is-regex@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
   dependencies:
     has "^1.0.1"
 
-is-stream@^1.1.0:
+is-retry-allowed@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
+
+is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -3062,7 +3300,7 @@ jquery-match-height@^0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/jquery-match-height/-/jquery-match-height-0.7.2.tgz#f8d9f3ba5314daab109cf07408674be204be5f0e"
 
-"jquery@>= 2.1.x", jquery@>=1.7, jquery@>=1.7.0, "jquery@>=1.7.1 <4.0.0", jquery@>=1.8, "jquery@^1.8.3 || ^2.0 || ^3.0":
+"jquery@>= 2.1.x", jquery@>=1.7, jquery@>=1.7.0, "jquery@>=1.7.1 <4.0.0", "jquery@^1.8.3 || ^2.0 || ^3.0":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
 
@@ -3107,6 +3345,10 @@ jsesc@~0.5.0:
 json-loader@^0.5.4:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.7.tgz#dca14a70235ff82f0ac9a3abeb60d337a365185d"
+
+json-parse-better-errors@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
 
 json-schema-traverse@^0.3.0:
   version "0.3.1"
@@ -3193,6 +3435,12 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
+latest-version@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz#a205383fea322b33b5ae3b18abee0dc2f356ee15"
+  dependencies:
+    package-json "^4.0.0"
+
 lazy-cache@^0.2.3:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-0.2.7.tgz#7feddf2dcb6edb77d11ef1d117ab5ffdf0ab1b65"
@@ -3257,6 +3505,15 @@ load-json-file@^2.0.0:
     graceful-fs "^4.1.2"
     parse-json "^2.2.0"
     pify "^2.0.0"
+    strip-bom "^3.0.0"
+
+load-json-file@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
     strip-bom "^3.0.0"
 
 loader-runner@^2.3.0:
@@ -3331,7 +3588,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.0.0, lodash@^4.11.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@~4.17.4:
+lodash@4.17.5, lodash@^4.0.0, lodash@^4.11.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@~4.17.4:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
@@ -3360,6 +3617,10 @@ lower-case@^1.1.1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
 
+lowercase-keys@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
+
 lru-cache@^4.0.1, lru-cache@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
@@ -3371,11 +3632,17 @@ macaddress@^0.2.8:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/macaddress/-/macaddress-0.2.8.tgz#5904dc537c39ec6dbefeae902327135fa8511f12"
 
-magic-string@^0.22.3:
+magic-string@0.22.4, magic-string@^0.22.3:
   version "0.22.4"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.22.4.tgz#31039b4e40366395618c1d6cf8193c53917475ff"
   dependencies:
     vlq "^0.2.1"
+
+magic-string@^0.22.4:
+  version "0.22.5"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.22.5.tgz#8e9cf5afddf44385c1da5bc2a6a0dbd10b03657e"
+  dependencies:
+    vlq "^0.2.2"
 
 make-dir@^1.0.0:
   version "1.1.0"
@@ -3539,9 +3806,22 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.0, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+
+minipass@^2.2.1, minipass@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.3.tgz#a7dcc8b7b833f5d368759cce544dccb55f50f233"
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
+minizlib@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.1.0.tgz#11e13658ce46bc3a70a267aac58359d1e0c29ceb"
+  dependencies:
+    minipass "^2.2.1"
 
 mississippi@^1.3.0:
   version "1.3.1"
@@ -3572,7 +3852,7 @@ mixin-object@^2.0.1:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
-mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -3584,9 +3864,13 @@ moment-timezone@^0.4.0, moment-timezone@^0.4.1:
   dependencies:
     moment ">= 2.6.0"
 
+moment@2.21.0:
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.21.0.tgz#2a114b51d2a6ec9e6d83cf803f838a878d8a023a"
+
 "moment@>= 2.6.0", moment@^2.10, moment@^2.19.1:
-  version "2.20.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.20.1.tgz#d6eb1a46cbcc14a2b2f9434112c1ff8907f313fd"
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.1.tgz#529a2e9bf973f259c9643d237fda84de3a26e8ad"
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -3613,6 +3897,10 @@ multicast-dns@^6.0.1:
   dependencies:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
+
+nan@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
 nan@^2.3.0, nan@^2.3.2:
   version "2.8.0"
@@ -3643,6 +3931,40 @@ ncname@1.0.x:
 negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
+
+ng-packagr@^2.0.0:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/ng-packagr/-/ng-packagr-2.4.5.tgz#b1d922d1e65dace54eada43172659f0976ce6541"
+  dependencies:
+    "@ngtools/json-schema" "^1.1.0"
+    autoprefixer "^7.1.1"
+    browserslist "^2.1.5"
+    chalk "^2.3.1"
+    commander "^2.12.0"
+    cpx "^1.5.0"
+    fs-extra "^5.0.0"
+    glob "^7.1.2"
+    injection-js "^2.2.1"
+    less "^2.7.2"
+    node-sass "^4.5.3"
+    node-sass-tilde-importer "^1.0.0"
+    postcss "^6.0.2"
+    postcss-clean "^1.1.0"
+    postcss-url "^7.3.0"
+    read-pkg-up "^3.0.0"
+    rimraf "^2.6.1"
+    rollup "^0.55.0"
+    rollup-plugin-cleanup "^2.0.0"
+    rollup-plugin-commonjs "8.3.0"
+    rollup-plugin-license "^0.6.0"
+    rollup-plugin-node-resolve "^3.0.0"
+    rxjs "^5.5.0"
+    sorcery "^0.10.0"
+    strip-bom "^3.0.0"
+    stylus "^0.54.5"
+    tar "^4.4.1"
+    uglify-js "^3.3.20"
+    update-notifier "^2.3.0"
 
 ngx-bootstrap@2.0.2:
   version "2.0.2"
@@ -3723,6 +4045,36 @@ node-pre-gyp@^0.6.39:
     semver "^5.3.0"
     tar "^2.2.1"
     tar-pack "^3.4.0"
+
+node-sass-tilde-importer@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/node-sass-tilde-importer/-/node-sass-tilde-importer-1.0.2.tgz#1a15105c153f648323b4347693fdb0f331bad1ce"
+  dependencies:
+    find-parent-dir "^0.3.0"
+
+node-sass@^4.5.3:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.9.0.tgz#d1b8aa855d98ed684d6848db929a20771cc2ae52"
+  dependencies:
+    async-foreach "^0.1.3"
+    chalk "^1.1.1"
+    cross-spawn "^3.0.0"
+    gaze "^1.0.0"
+    get-stdin "^4.0.1"
+    glob "^7.0.3"
+    in-publish "^2.0.0"
+    lodash.assign "^4.2.0"
+    lodash.clonedeep "^4.3.2"
+    lodash.mergewith "^4.6.0"
+    meow "^3.7.0"
+    mkdirp "^0.5.1"
+    nan "^2.10.0"
+    node-gyp "^3.3.1"
+    npmlog "^4.0.0"
+    request "~2.79.0"
+    sass-graph "^2.2.4"
+    stdout-stream "^1.4.0"
+    "true-case-path" "^1.0.2"
 
 node-sass@^4.7.2:
   version "4.7.2"
@@ -3965,6 +4317,15 @@ p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
 
+package-json@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/package-json/-/package-json-4.0.1.tgz#8869a0401253661c4c4ca3da6c2121ed555f5eed"
+  dependencies:
+    got "^6.7.1"
+    registry-auth-token "^3.0.1"
+    registry-url "^3.0.3"
+    semver "^5.1.0"
+
 pako@~1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.6.tgz#0101211baa70c4bca4a0f63f2206e97b7dfaf258"
@@ -4007,6 +4368,13 @@ parse-json@^2.2.0:
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
   dependencies:
     error-ex "^1.2.0"
+
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
 
 parse-passwd@^1.0.0:
   version "1.0.0"
@@ -4180,6 +4548,13 @@ postcss-calc@^5.2.0:
     postcss "^5.0.2"
     postcss-message-helpers "^2.0.0"
     reduce-css-calc "^1.2.6"
+
+postcss-clean@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-clean/-/postcss-clean-1.1.0.tgz#c2d61d5d8caf19a585adba16897726c2674c4207"
+  dependencies:
+    clean-css "^4.x"
+    postcss "^6.x"
 
 postcss-colormin@^2.1.8:
   version "2.2.2"
@@ -4441,6 +4816,16 @@ postcss-url@^7.1.2:
     postcss "^6.0.1"
     xxhashjs "^0.2.1"
 
+postcss-url@^7.3.0:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/postcss-url/-/postcss-url-7.3.2.tgz#5fea273807fb84b38c461c3c9a9e8abd235f7120"
+  dependencies:
+    mime "^1.4.1"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.0"
+    postcss "^6.0.1"
+    xxhashjs "^0.2.1"
+
 postcss-value-parser@^3.0.1, postcss-value-parser@^3.0.2, postcss-value-parser@^3.1.1, postcss-value-parser@^3.1.2, postcss-value-parser@^3.2.3, postcss-value-parser@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz#87f38f9f18f774a4ab4c8a232f5c5ce8872a9d15"
@@ -4470,7 +4855,15 @@ postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.17:
     source-map "^0.6.1"
     supports-color "^5.2.0"
 
-prepend-http@^1.0.0:
+postcss@^6.0.2, postcss@^6.x:
+  version "6.0.22"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.22.tgz#e23b78314905c3b90cbd61702121e7a78848f2a3"
+  dependencies:
+    chalk "^2.4.1"
+    source-map "^0.6.1"
+    supports-color "^5.4.0"
+
+prepend-http@^1.0.0, prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
 
@@ -4634,6 +5027,15 @@ raw-loader@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-0.5.1.tgz#0c3d0beaed8a01c966d9787bf778281252a979aa"
 
+rc@^1.0.1, rc@^1.1.6:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.7.tgz#8a10ca30d588d00464360372b890d06dacd02297"
+  dependencies:
+    deep-extend "^0.5.1"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
+
 rc@^1.1.7:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.5.tgz#275cd687f6e3b36cc756baa26dfee80a790301fd"
@@ -4663,6 +5065,13 @@ read-pkg-up@^2.0.0:
     find-up "^2.0.0"
     read-pkg "^2.0.0"
 
+read-pkg-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-3.0.0.tgz#3ed496685dba0f8fe118d0691dc51f4a1ff96f07"
+  dependencies:
+    find-up "^2.0.0"
+    read-pkg "^3.0.0"
+
 read-pkg@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
@@ -4678,6 +5087,14 @@ read-pkg@^2.0.0:
     load-json-file "^2.0.0"
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
+
+read-pkg@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
+  dependencies:
+    load-json-file "^4.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^3.0.0"
 
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.9, readable-stream@^2.3.3:
   version "2.3.4"
@@ -4761,6 +5178,19 @@ regexpu-core@^1.0.0:
     regenerate "^1.2.1"
     regjsgen "^0.2.0"
     regjsparser "^0.1.4"
+
+registry-auth-token@^3.0.1:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-3.3.2.tgz#851fd49038eecb586911115af845260eec983f20"
+  dependencies:
+    rc "^1.1.6"
+    safe-buffer "^5.0.1"
+
+registry-url@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942"
+  dependencies:
+    rc "^1.0.1"
 
 regjsgen@^0.2.0:
   version "0.2.0"
@@ -4913,6 +5343,12 @@ resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
 
+resolve@^1.1.6, resolve@^1.4.0:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.7.1.tgz#aadd656374fd298aee895bc026b8297418677fd3"
+  dependencies:
+    path-parse "^1.0.5"
+
 resolve@^1.1.7:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
@@ -4925,7 +5361,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -4938,11 +5374,64 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^2.0.0"
     inherits "^2.0.1"
 
+rollup-plugin-cleanup@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-cleanup/-/rollup-plugin-cleanup-2.0.1.tgz#62c510fe868a77000f33cf13b519fb36a9fbe2ed"
+  dependencies:
+    acorn "4.x"
+    magic-string "^0.22.4"
+    rollup-pluginutils "^2.0.1"
+
+rollup-plugin-commonjs@8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.3.0.tgz#91b4ba18f340951e39ed7b1901f377a80ab3f9c3"
+  dependencies:
+    acorn "^5.2.1"
+    estree-walker "^0.5.0"
+    magic-string "^0.22.4"
+    resolve "^1.4.0"
+    rollup-pluginutils "^2.0.1"
+
+rollup-plugin-license@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-license/-/rollup-plugin-license-0.6.0.tgz#d8e5e75ac0fcb5a7af7c5d89a644ef42f05f48a4"
+  dependencies:
+    commenting "1.0.5"
+    lodash "4.17.5"
+    magic-string "0.22.4"
+    mkdirp "0.5.1"
+    moment "2.21.0"
+
+rollup-plugin-node-resolve@^3.0.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.3.0.tgz#c26d110a36812cbefa7ce117cadcd3439aa1c713"
+  dependencies:
+    builtin-modules "^2.0.0"
+    is-module "^1.0.0"
+    resolve "^1.1.6"
+
+rollup-pluginutils@^2.0.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.3.0.tgz#478ace04bd7f6da2e724356ca798214884738fc4"
+  dependencies:
+    estree-walker "^0.5.2"
+    micromatch "^2.3.11"
+
+rollup@^0.55.0:
+  version "0.55.5"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.55.5.tgz#2f88c300f7cf24b5ec2dca8a6aba73b04e087e93"
+
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/run-queue/-/run-queue-1.0.3.tgz#e848396f057d223f24386924618e25694161ec47"
   dependencies:
     aproba "^1.1.1"
+
+rxjs@^5.5.0:
+  version "5.5.11"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.11.tgz#f733027ca43e3bec6b994473be4ab98ad43ced87"
+  dependencies:
+    symbol-observable "1.0.1"
 
 rxjs@^5.5.6:
   version "5.5.6"
@@ -4953,6 +5442,19 @@ rxjs@^5.5.6:
 safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+
+safe-buffer@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+
+sander@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/sander/-/sander-0.5.1.tgz#741e245e231f07cafb6fdf0f133adfa216a502ad"
+  dependencies:
+    es6-promise "^3.1.2"
+    graceful-fs "^4.1.3"
+    mkdirp "^0.5.1"
+    rimraf "^2.5.2"
 
 sass-graph@^2.2.4:
   version "2.2.4"
@@ -5011,7 +5513,13 @@ selfsigned@^1.9.1:
   dependencies:
     node-forge "0.7.1"
 
-"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0:
+semver-diff@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36"
+  dependencies:
+    semver "^5.0.3"
+
+"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
@@ -5132,7 +5640,16 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-signal-exit@^3.0.0:
+shell-quote@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.6.1.tgz#f4781949cce402697127430ea3b3c5476f481767"
+  dependencies:
+    array-filter "~0.0.0"
+    array-map "~0.0.0"
+    array-reduce "~0.0.0"
+    jsonify "~0.0.0"
+
+signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
@@ -5203,6 +5720,15 @@ sockjs@0.3.19:
     faye-websocket "^0.10.0"
     uuid "^3.0.1"
 
+sorcery@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/sorcery/-/sorcery-0.10.0.tgz#8ae90ad7d7cb05fc59f1ab0c637845d5c15a52b7"
+  dependencies:
+    buffer-crc32 "^0.2.5"
+    minimist "^1.2.0"
+    sander "^0.5.0"
+    sourcemap-codec "^1.3.0"
+
 sort-keys@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-1.1.2.tgz#441b6d4d346798f1b4e49e8920adfba0e543f9ad"
@@ -5262,6 +5788,10 @@ source-map@^0.4.2, source-map@~0.4.1:
 source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+
+sourcemap-codec@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.1.tgz#c8fd92d91889e902a07aee392bdd2c5863958ba2"
 
 spdx-correct@~1.0.0:
   version "1.0.2"
@@ -5391,7 +5921,7 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.0.0:
+string-width@^2.0.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
@@ -5473,6 +6003,12 @@ stylus@^0.54.5:
     sax "0.5.x"
     source-map "0.1.x"
 
+subarg@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/subarg/-/subarg-1.0.0.tgz#f62cf17581e996b48fc965699f54c06ae268b8d2"
+  dependencies:
+    minimist "^1.1.0"
+
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -5492,6 +6028,12 @@ supports-color@^4.0.0, supports-color@^4.2.1:
 supports-color@^5.1.0, supports-color@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.2.0.tgz#b0d5333b1184dd3666cbe5aa0b45c5ac7ac17a4a"
+  dependencies:
+    has-flag "^3.0.0"
+
+supports-color@^5.3.0, supports-color@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
   dependencies:
     has-flag "^3.0.0"
 
@@ -5536,6 +6078,24 @@ tar@^2.0.0, tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
+tar@^4.4.1:
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.4.tgz#ec8409fae9f665a4355cc3b4087d0820232bb8cd"
+  dependencies:
+    chownr "^1.0.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.3.3"
+    minizlib "^1.1.0"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.2"
+    yallist "^3.0.2"
+
+term-size@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
+  dependencies:
+    execa "^0.7.0"
+
 through2@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
@@ -5550,6 +6110,10 @@ thunky@^1.0.2:
 time-stamp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-2.0.0.tgz#95c6a44530e15ba8d6f4a3ecb8c3a3fac46da357"
+
+timed-out@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
 
 timers-browserify@^2.0.4:
   version "2.0.6"
@@ -5648,8 +6212,8 @@ tsickle@^0.26.0:
     source-map-support "^0.4.2"
 
 tslib@^1.7.1:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.1.tgz#a5d1f0532a49221c87755cfcc89ca37197242ba7"
 
 tty-browserify@0.0.0:
   version "0.0.0"
@@ -5710,6 +6274,13 @@ uglify-js@^2.8.29:
     yargs "~3.10.0"
   optionalDependencies:
     uglify-to-browserify "~1.0.0"
+
+uglify-js@^3.3.20:
+  version "3.3.27"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.3.27.tgz#eb8c3c9429969f86ff5b0a2422ffc78c3cea8cc0"
+  dependencies:
+    commander "~2.15.0"
+    source-map "~0.6.1"
 
 uglify-to-browserify@~1.0.0:
   version "1.0.2"
@@ -5775,6 +6346,12 @@ unique-slug@^2.0.0:
   dependencies:
     imurmurhash "^0.1.4"
 
+unique-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
+  dependencies:
+    crypto-random-string "^1.0.0"
+
 universalify@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
@@ -5790,6 +6367,10 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
+unzip-response@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
+
 upath@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.0.2.tgz#80aaae5395abc5fd402933ae2f58694f0860204c"
@@ -5798,6 +6379,21 @@ upath@^1.0.0:
     lodash.isfunction "^3.0.8"
     lodash.isstring "^4.0.1"
     lodash.startswith "^4.2.1"
+
+update-notifier@^2.3.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.5.0.tgz#d0744593e13f161e406acb1d9408b72cad08aff6"
+  dependencies:
+    boxen "^1.2.1"
+    chalk "^2.0.1"
+    configstore "^3.0.0"
+    import-lazy "^2.1.0"
+    is-ci "^1.0.10"
+    is-installed-globally "^0.1.0"
+    is-npm "^1.0.0"
+    latest-version "^3.0.0"
+    semver-diff "^2.0.0"
+    xdg-basedir "^3.0.0"
 
 upper-case@^1.1.1:
   version "1.1.3"
@@ -5814,6 +6410,12 @@ url-loader@^0.6.2:
     loader-utils "^1.0.2"
     mime "^1.4.1"
     schema-utils "^0.3.0"
+
+url-parse-lax@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
+  dependencies:
+    prepend-http "^1.0.1"
 
 url-parse@1.0.x:
   version "1.0.5"
@@ -5899,7 +6501,7 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vlq@^0.2.1:
+vlq@^0.2.1, vlq@^0.2.2:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.3.tgz#8f3e4328cf63b1540c0d67e1b2778386f8975b26"
 
@@ -6057,6 +6659,12 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2"
 
+widest-line@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-2.0.0.tgz#0142a4e8a243f8882c0233aa0e0281aa76152273"
+  dependencies:
+    string-width "^2.1.1"
+
 window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
@@ -6083,6 +6691,18 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
+write-file-atomic@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.3.0.tgz#1ff61575c2e2a4e8e510d6fa4e243cce183999ab"
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    signal-exit "^3.0.2"
+
+xdg-basedir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
+
 xml-char-classes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/xml-char-classes/-/xml-char-classes-1.0.0.tgz#64657848a20ffc5df583a42ad8a277b4512bbc4d"
@@ -6104,6 +6724,10 @@ y18n@^3.2.1:
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+
+yallist@^3.0.0, yallist@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
 
 yamljs@0.3.0:
   version "0.3.0"
@@ -6198,5 +6822,5 @@ yn@^2.0.0:
   resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"
 
 zone.js@^0.8.19:
-  version "0.8.20"
-  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.8.20.tgz#a218c48db09464b19ff6fc8f0d4bb5b1046e185d"
+  version "0.8.26"
+  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.8.26.tgz#7bdd72f7668c5a7ad6b118148b4ea39c59d08d2d"


### PR DESCRIPTION
In https://github.com/syndesisio/syndesis we're considering embedding a OpenAPI editor functionality of Apicurio. To do this we would like to depend on a Angular module that contains only the `ApiEditorComponent`.

This is the first step in creating an Angular package that only exposes the `ApiEditorComponent`. More details are provided in the individual commit messages.

The base commit that accomplishes the creation of the package and exposes the `ApiEditorComponent` is in 8402911. This is done by using https://github.com/dherges/ng-packagr/. Other commits resolve errors/warnings emitted from the ahead of time compilation.

Next steps might be to use this `ApicurioEditorModule` internally within Apicurio so that it's always up to date with the dependencies or other code changes to the `ApiEditorComponent`, or to create a test that embeds the `ApiEditorComponent` from the `ApicurioEditorModule` to validate the embedding scenario.