### PR TITLE
Fixes Syndesis Issue 3497: Apicurio GUI - info box not showed properly

### DIFF
--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/common/context-help.component.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/common/context-help.component.html
@@ -1,6 +1,6 @@
 <span class="context-help" (window:keydown)="onGlobalKeyDown($event)">
     <a (click)="open($event)"><span class="context-help-icon fa fa-fw fa-info-circle"></span></a>
-    <div #helppanel *ngIf="isOpen()" class="context-help-panel" [style.left]="left" [style.top]="top">
+    <div #helppanel *ngIf="isOpen()" class="context-help-panel">
         <ng-content></ng-content>
     </div>
 </span>

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/common/context-help.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/common/context-help.component.ts
@@ -26,9 +26,6 @@ export class ContextHelpComponent {
 
     private _open: boolean = false;
 
-    public left: string;
-    public top: string;
-
     @HostListener("document:click", ["$event"])
     public onDocumentClick(event: MouseEvent): void {
         if (this._open) {
@@ -37,8 +34,6 @@ export class ContextHelpComponent {
     }
 
     public open(event: MouseEvent): void {
-        this.left = event.clientX + "px";
-        this.top = event.clientY + "px";
         event.preventDefault();
         event.stopPropagation();
         this._open = true;

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/editor.component.css
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/editor.component.css
@@ -240,7 +240,8 @@
 
 .api-editor .context-help {
   margin-left: 10px;
-  display: none;
+  position: relative;
+  /*display: none;*/
 }
 .api-editor .context-help a {
   cursor: pointer;
@@ -253,7 +254,8 @@
   transition: opacity 300ms;
 }
 .api-editor .context-help .context-help-panel {
-  position: fixed;
+  position: absolute;
+  left: 0;
   margin: 0;
   padding: 10px 14px;
   border: 1px solid #bbb;
@@ -264,7 +266,7 @@
   font-size: 12px;
   font-style: normal;
   font-weight: 400;
-  max-width: 450px;
+  width: 450px;
   cursor: default;
 }
 .api-editor .context-help .context-help-panel p {


### PR DESCRIPTION
- when info box extends below bottom of window user can now scroll the window to see entire contents
- removed `left` and `right` properties from the `ContextHelpComponent`
- info box positioning is all  done in the css now