### PR TITLE
Adding Header parameters to design view

### DIFF
--- a/front-end/studio/src/app/editor.module.ts
+++ b/front-end/studio/src/app/editor.module.ts
@@ -66,6 +66,7 @@ import {SecurityRequirementsSectionComponent} from "./pages/apis/{apiId}/editor/
 import {SecuritySchemesSectionComponent} from "./pages/apis/{apiId}/editor/_components/forms/main/security-schemes-section.component";
 import {PathParamsSectionComponent} from "./pages/apis/{apiId}/editor/_components/forms/shared/path-params-section.component";
 import {QueryParamsSectionComponent} from "./pages/apis/{apiId}/editor/_components/forms/shared/query-params-section.component";
+import {HeaderParamsSectionComponent} from "./pages/apis/{apiId}/editor/_components/forms/shared/header-params-section.component";
 import {DocumentService} from "./pages/apis/{apiId}/editor/_services/document.service";
 import {PfInlineTextEditorComponent} from "./pages/apis/{apiId}/editor/_components/common/pf-inline-text-editor.component";
 import {TagRowComponent} from "./pages/apis/{apiId}/editor/_components/forms/main/tag-row.component";
@@ -81,6 +82,7 @@ import {SecurityRequirementEditorComponent} from "./pages/apis/{apiId}/editor/_c
 import {EntityEditorComponent} from "./pages/apis/{apiId}/editor/_components/editors/entity-editor.component";
 import {QueryParamRowComponent} from "./pages/apis/{apiId}/editor/_components/forms/shared/query-param-row.component";
 import {PathParamRowComponent} from "./pages/apis/{apiId}/editor/_components/forms/shared/path-param-row.component";
+import {HeaderParamRowComponent} from "./pages/apis/{apiId}/editor/_components/forms/shared/header-param-row.component";
 import {InlineMarkdownEditorComponent} from "./pages/apis/{apiId}/editor/_components/common/inline-markdown-editor.component";
 import {DataTypeEditorComponent} from "./pages/apis/{apiId}/editor/_components/editors/data-type-editor.component";
 import {DefinitionInfoSectionComponent} from "./pages/apis/{apiId}/editor/_components/forms/definition/info-section.component";
@@ -127,8 +129,8 @@ import {ScopesInputComponent} from "./pages/apis/{apiId}/editor/_components/comm
         PfInlineTextEditorComponent, TagRowComponent, ServerEditorComponent, ServerRowComponent, EntityEditorComponent,
         InlineArrayEditorComponent, SecuritySchemeRowComponent, SecuritySchemeEditorComponent, DataTypeEditorComponent,
         DefinitionInfoSectionComponent, RenamePathDialogComponent, CounterComponent, ResponsesSectionComponent,
-        InlineExampleEditorComponent, DefinitionExampleSectionComponent, PropertyEditorComponent,
-        OperationsSectionComponent
+        InlineExampleEditorComponent, DefinitionExampleSectionComponent, PropertyEditorComponent, HeaderParamRowComponent,
+        HeaderParamsSectionComponent, OperationsSectionComponent
     ],
     providers: [
         ProblemsService, SelectionService, LicenseService, CommandService, DocumentService, EditorsService,

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/path-form.component.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/path-form.component.html
@@ -94,6 +94,9 @@
                 <!-- Query Parameters Section -->
                 <query-params-section [parent]="path" [path]="path"></query-params-section>
 
+                <!-- Header Parameters Section -->
+                <header-params-section [parent]="path" [path]="path"></header-params-section>
+
                 <!-- Operations Section -->
                 <operations-section [path]="path"></operations-section>
             </div>

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/path/operations-section.component.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/path/operations-section.component.html
@@ -67,6 +67,9 @@
             <!-- Query Parameters Section -->
             <query-params-section [parent]="operation()" [path]="path"></query-params-section>
 
+            <!-- Header Parameters Section -->
+            <header-params-section [parent]="operation()" [path]="path"></header-params-section>
+
             <!-- Request Body Section -->
             <requestBody-section [operation]="operation()"></requestBody-section>
 

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/header-param-row.component.css
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/header-param-row.component.css
@@ -1,0 +1,137 @@
+.header-param {
+  border: 1px solid transparent;
+  position: relative;
+}
+.header-param.expanded {
+  border: 1px solid #bbb;
+  box-shadow: 0 2px 6px rgba(3,3,3,.2);
+  margin-bottom: 3px;
+}
+
+.header-param .header {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  padding: 8px;
+  padding-bottom: 3px;
+  border-bottom: 1px solid #f5f5f5;
+}
+.header-param .header:hover {
+  background-color: #edf8ff;
+}
+.header-param.expanded .header {
+  border-bottom: solid 1px #bbb;
+  background-color: #def3ff;
+}
+
+.header-param .header .name {
+  flex-basis: 16%;
+  overflow-x: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding-right: 5px;
+}
+.header-param .header .name > span {
+  font-weight: 600;
+  color: #39a5dc;
+}
+.header-param .header .name .icon-override {
+  font-size: 16px;
+  font-weight: normal;
+  cursor: help;
+  margin-right: 3px;
+}
+
+.header-param .header .description {
+  flex-basis: 41%;
+  overflow-x: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding-right: 15px;
+}
+.header-param .header .description:hover {
+  color: #0088ce;
+  cursor: pointer;
+}
+.header-param .header .summary {
+  flex-basis: 41%;
+}
+.header-param .header .summary:hover {
+  color: #0088ce;
+  cursor: pointer;
+}
+
+.header-param .header .summary .parameter-required {
+  font-weight: 600;
+}
+.header-param .header .summary .parameter-required:hover {
+  filter: brightness(120%);
+}
+
+.header-param .header .actions {
+  flex-basis: 2%;
+  text-align: center;
+}
+
+.header-param .header .actions .btn-override {
+  position: absolute;
+  right: 5px;
+  top: 6px;
+}
+
+.header-param .header .actions > div .fa-ellipsis-v {
+  visibility: hidden;
+}
+.header-param:hover .header .actions > div .fa-ellipsis-v {
+  visibility: visible;
+}
+
+.header-param .header > .selected {
+  margin-bottom: -4px;
+  border-bottom: 2px solid #0088ce;
+  color: #0088ce;
+}
+
+.header-param .body {
+  position: relative;
+  padding: 15px;
+}
+.header-param .body .close {
+  position: absolute;
+  right: 10px;
+  top: 5px;
+}
+
+.header-param .body .param-description form {
+  width: 100%;
+}
+.header-param .body .param-description .form-label {
+  font-weight: 600;
+}
+
+.header-param .body span.strong {
+  font-weight: 600;
+}
+
+.header-param .body .param-required {
+  margin-bottom: 20px;
+}
+.header-param .body .param-type {
+  margin-bottom: 10px;
+}
+
+.header-param .body .param-required .dropdown {
+  display: inline-block;
+  margin-left: 3px;
+  margin-right: 3px;
+}
+
+
+.header-param.overridable > .header > div > .fa-angle-right {
+  display: none;
+}
+.header-param.overridable .header .description:hover, .header-param.overridable .header .summary:hover {
+  color: inherit;
+  cursor: default;
+}
+  

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/header-param-row.component.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/header-param-row.component.html
@@ -1,0 +1,65 @@
+<div class="header-param" [class.expanded]="isEditing()" [class.required]="isRequired()" [class.overridable]="isOverridable()">
+    <div class="header">
+        <div class="name">
+            <validation-problem [model]="parameter"></validation-problem>
+            <span class="apicurio-icon-override icon-override" *ngIf="isParentOperation() && isOverride()"
+                  title="Overrides a parameter defined at the Path level."></span>
+            <span class="apicurio-icon-inherit-d icon-override" *ngIf="isParentOperation() && isOverridable()"
+                  title="Header parameter inherited from the Path level."></span>
+            <span class="apicurio-icon-local-d icon-override" *ngIf="isParentOperation() && isLocalOnly()"
+                  title="Header parameter defined for this operation only."></span>
+            <span title="{{ parameter.name }}">{{ parameter.name }}</span>
+        </div>
+        <div class="description" (click)="toggleDescription()" [class.selected]="isEditingDescription()">
+            <span class="fa fa-angle-right" [class.fa-angle-down]="isEditingDescription()"></span>
+            <markdown-summary [data]="description()" emptyText="No description."></markdown-summary>
+        </div>
+        <div class="summary" (click)="toggleSummary()" [class.selected]="isEditingSummary()">
+            <span class="fa fa-angle-right" [class.fa-angle-down]="isEditingSummary()"></span>
+            <span class="parameter-required" *ngIf="isRequired()" title="This header parameter is required.">[required]</span>
+            <schema-type [type]="displayType()"></schema-type>
+        </div>
+        <div class="actions">
+            <div class="dropdown dropdown-kebab-pf" *ngIf="!isOverridable()">
+                <button class="btn btn-link dropdown-toggle" type="button" (click)="$event.preventDefault()"
+                        data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                    <span class="fa fa-ellipsis-v"></span>
+                </button>
+                <ul class="dropdown-menu dropdown-menu-right">
+                    <li><a (click)="rename()"><span class="fa fa-fw fa-pencil-square-o"></span><span>Rename</span></a></li>
+                    <li role="separator" class="divider"></li>
+                    <li><a (click)="delete()"><span class="fa fa-fw fa-trash"></span><span>Delete</span></a></li>
+                </ul>
+            </div>
+            <button *ngIf="isOverridable()" (click)="override()" title="Override the header parameter."
+                    class="btn btn-default btn-xs btn-override">Override</button>
+        </div>
+    </div>
+    <div class="body" *ngIf="isEditing()">
+        <div class="content container-fluid">
+            <form  class="form-horizontal">
+                <div class="col-md-11">
+                    <div class="param-description" *ngIf="isEditingDescription()">
+                        <div class="form-label">Description</div>
+                        <inline-markdown-editor [value]="parameter.description" [noValueMessage]="'No description.'"
+                                                (onChange)="setDescription($event)"></inline-markdown-editor>
+                    </div>
+                    <div class="param-content" *ngIf="isEditingSummary()">
+                        <div class="param-required">
+                            <span>Parameter is</span>
+                            <drop-down [id]="'api-param-required'"
+                                       [value]="required()"
+                                       [options]="requiredOptions()"
+                                       (onValueChange)="changeRequired($event)"
+                                       [noSelectionLabel]="'Not Required'"></drop-down>
+                        </div>
+                        <div class="param-type">
+                            <schema-type-editor [document]="document()" [value]="model()" [isParameter]="isParameter()"
+                                                (onChange)="changeType($event)"></schema-type-editor>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/header-param-row.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/header-param-row.component.ts
@@ -1,0 +1,293 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    ChangeDetectionStrategy, ChangeDetectorRef,
+    Component,
+    EventEmitter,
+    Input,
+    OnChanges,
+    OnDestroy,
+    OnInit,
+    Output,
+    SimpleChanges,
+    ViewEncapsulation
+} from "@angular/core";
+import {
+    createChangeParameterTypeCommand,
+    createChangePropertyCommand,
+    createNewParamCommand,
+    ICommand,
+    SimplifiedParameterType,
+    SimplifiedType
+} from "oai-ts-commands";
+import {OasCombinedVisitorAdapter, OasDocument, OasOperation, OasParameterBase, OasPathItem} from "oai-ts-core";
+import {DropDownOption} from '../../../../../../../components/common/drop-down.component';
+import {CommandService} from "../../../_services/command.service";
+import {DocumentService} from "../../../_services/document.service";
+import {Subscription} from "rxjs";
+import {AbstractBaseComponent} from "../../common/base-component";
+import {SelectionService} from "../../../_services/selection.service";
+
+
+@Component({
+    moduleId: module.id,
+    selector: "header-param-row",
+    templateUrl: "header-param-row.component.html",
+    styleUrls: [ "header-param-row.component.css" ],
+    encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class HeaderParamRowComponent extends AbstractBaseComponent {
+
+    @Input() parameter: OasParameterBase;
+    private _overriddenParam: OasParameterBase;
+
+    @Output() onDelete: EventEmitter<void> = new EventEmitter<void>();
+
+    protected _editing: boolean = false;
+    protected _tab: string = "description";
+    protected _model: SimplifiedParameterType = null;
+    private _parentType: string;
+
+    private overrideFlag: boolean;
+    private missingFlag: boolean;
+
+    constructor(private changeDetectorRef: ChangeDetectorRef, private documentService: DocumentService,
+                private commandService: CommandService, private selectionService: SelectionService) {
+        super(changeDetectorRef, documentService, selectionService);
+    }
+
+    protected onDocumentChange(): void {
+        this.updateModel();
+    }
+
+    public ngOnChanges(changes: SimpleChanges): void {
+        super.ngOnChanges(changes);
+        if (changes["parameter"]) {
+            this.updateModel();
+        }
+    }
+
+    private updateModel(): void {
+        this._model = SimplifiedParameterType.fromParameter(this.parameter as any);
+        this.missingFlag = this.parameter.n_attribute("missing") === true;
+        this._overriddenParam = this.getOverriddenParam(this.parameter);
+        this.overrideFlag = this._overriddenParam !== null;
+        this._parentType = this.detectParentType();
+    }
+
+    public isParentOperation(): boolean {
+        return this._parentType === "operation";
+    }
+
+    public isParentPath(): boolean {
+        return this._parentType === "pathItem";
+    }
+
+    public model(): SimplifiedParameterType {
+        return this._model;
+    }
+
+    public document(): OasDocument {
+        return this.parameter.ownerDocument();
+    }
+
+    public isParameter(): boolean {
+        return true;
+    }
+
+    public hasDescription(): boolean {
+        if (this.parameter.description) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public description(): string {
+        return this.parameter.description
+    }
+
+    public isRequired(): boolean {
+        return this.parameter.required;
+    }
+
+    public required(): string {
+        return this.isRequired() ? "required" : "not-required";
+    }
+
+    public requiredOptions(): DropDownOption[] {
+        return [
+            { name: "Required", value: "required" },
+            { name: "Not Required", value: "not-required" }
+        ];
+    }
+
+    public isEditing(): boolean {
+        return this._editing;
+    }
+
+    public isEditingDescription(): boolean {
+        return this._editing && this._tab === "description";
+    }
+
+    public isEditingSummary(): boolean {
+        return this._editing && this._tab === "summary";
+    }
+
+    public toggle(event: MouseEvent): void {
+        if (event.target['localName'] !== "button" && event.target['localName'] !== "a") {
+            this._editing = !this._editing;
+        }
+    }
+
+    public toggleDescription(): void {
+        if (this.isOverridable()) {
+            this._editing = false;
+            return;
+        }
+        if (this.isEditing() && this._tab === "description") {
+            this._editing = false;
+        } else {
+            this._editing = true;
+            this._tab = "description";
+        }
+    }
+
+    public toggleSummary(): void {
+        if (this.isOverridable()) {
+            this._editing = false;
+            return;
+        }
+        if (this.isEditing() && this._tab === "summary") {
+            this._editing = false;
+        } else {
+            this._editing = true;
+            this._tab = "summary";
+        }
+    }
+
+    public delete(): void {
+        this.onDelete.emit();
+    }
+
+    public isValid(): boolean {
+        return true;
+    }
+
+    public displayType(): SimplifiedParameterType {
+        return SimplifiedParameterType.fromParameter(this.parameter as any);
+    }
+
+    public rename(): void {
+        // TODO implement this!
+        alert("Not yet implemented.");
+    }
+
+    public setDescription(description: string): void {
+        let command: ICommand = createChangePropertyCommand<string>(this.parameter.ownerDocument(), this.parameter, "description", description);
+        this.commandService.emit(command);
+    }
+
+    public changeRequired(newValue: string): void {
+        this.model().required = newValue === "required";
+        let command: ICommand = createChangePropertyCommand<boolean>(this.parameter.ownerDocument(), this.parameter, "required", this.model().required);
+        this.commandService.emit(command);
+    }
+
+    public changeType(newType: SimplifiedType): void {
+        let nt: SimplifiedParameterType = new SimplifiedParameterType();
+        nt.required = this.model().required;
+        nt.type = newType.type;
+        nt.enum = newType.enum;
+        nt.of = newType.of;
+        nt.as = newType.as;
+        let command: ICommand = createChangeParameterTypeCommand(this.parameter.ownerDocument(), this.parameter as any, nt);
+        this.commandService.emit(command);
+        this._model = nt;
+    }
+
+    public override(): void {
+        let command: ICommand = createNewParamCommand(this.parameter.ownerDocument(), this.parameter.parent() as any,
+            this.parameter.name, "header", null, null, true);
+        this.commandService.emit(command);
+    }
+
+    public isMissing(): boolean {
+        return this.missingFlag && !this.overrideFlag;
+    }
+
+    public isExists(): boolean {
+        return !this.missingFlag;
+    }
+
+    public isOverride(): boolean {
+        return !this.missingFlag && this.overrideFlag;
+    }
+
+    public isOverridable(): boolean {
+        return this.missingFlag && this.overrideFlag;
+    }
+
+    public isLocalOnly(): boolean {
+        return !this.overrideFlag && !this.missingFlag;
+    }
+
+    public getOverriddenParam(param: OasParameterBase): OasParameterBase {
+        let viz: DetectOverrideVisitor = new DetectOverrideVisitor(param);
+        param.parent().accept(viz);
+        return viz.overriddenParam;
+    }
+
+    private detectParentType(): string {
+        let viz: DetectParentTypeVisitor = new DetectParentTypeVisitor();
+        this.parameter.parent().accept(viz);
+        return viz.parentType;
+    }
+
+}
+
+
+class DetectOverrideVisitor extends OasCombinedVisitorAdapter {
+
+    public overriddenParam: OasParameterBase = null;
+
+    constructor(private param: OasParameterBase) {
+        super();
+    }
+
+    public visitOperation(node: OasOperation): void {
+        this.overriddenParam = (<OasPathItem>node.parent()).parameter(this.param.in, this.param.name) as OasParameterBase;
+    }
+
+}
+
+
+class DetectParentTypeVisitor extends OasCombinedVisitorAdapter {
+
+    public parentType: string = null;
+
+    public visitOperation(node: OasOperation): void {
+        this.parentType = "operation";
+    }
+
+    public visitPathItem(node: OasPathItem): void {
+        this.parentType = "pathItem";
+    }
+
+}

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/header-params-section.component.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/header-params-section.component.html
@@ -1,0 +1,24 @@
+<!-- Header Parameters Section -->
+<section type="header-parameters" label="HEADER PARAMETERS" [counterItems]="headerParameters()"
+         [contextHelp]="contextHelp()" [expanded]="showSectionBody"
+         [validationModels]="headerParameters()">
+    <span actions>
+        <icon-button (onClick)="openAddHeaderParamEditor()" [pullRight]="true" type="add"
+                     [title]="'Add a new header parameter.'"></icon-button>
+        <icon-button (onClick)="deleteAllHeaderParams()" [disabled]="!hasHeaderParameters()"
+                     [pullRight]="true" type="delete"
+                     [title]="'Delete all header parameters.'"></icon-button>
+    </span>
+    <div body>
+        <signpost *ngIf="!hasHeaderParameters()">
+            <span>No header parameters have been defined.</span>
+            <a (click)="openAddHeaderParamEditor()">Add a header parameter</a>
+        </signpost>
+
+        <!-- The list of header parameters -->
+        <div class="container-fluid header-parameters typed-item-list" *ngIf="hasHeaderParameters()">
+            <header-param-row *ngFor="let param of headerParameters()" [parameter]="param"
+                             (onDelete)="deleteParam(param)"></header-param-row>
+        </div>
+    </div>
+</section>

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/header-params-section.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/header-params-section.component.ts
@@ -1,0 +1,191 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
+    Component,
+    Input,
+    SimpleChanges,
+    ViewEncapsulation
+} from "@angular/core";
+import {
+    Oas20Operation,
+    Oas20Parameter,
+    Oas20PathItem,
+    Oas30Operation,
+    Oas30Parameter,
+    Oas30PathItem,
+    OasLibraryUtils,
+    OasPathItem
+} from "oai-ts-core";
+import {CommandService} from "../../../_services/command.service";
+import {
+    createDeleteAllParametersCommand,
+    createDeleteParameterCommand,
+    createNewParamCommand,
+    ICommand
+} from "oai-ts-commands";
+import {DocumentService} from "../../../_services/document.service";
+import {EditorsService} from "../../../_services/editors.service";
+import {
+    IParameterEditorHandler,
+    ParameterData,
+    ParameterEditorComponent
+} from "../../editors/parameter-editor.component";
+import {AbstractBaseComponent} from "../../common/base-component";
+import {SelectionService} from "../../../_services/selection.service";
+
+
+@Component({
+    moduleId: module.id,
+    selector: "header-params-section",
+    templateUrl: "header-params-section.component.html",
+    encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class HeaderParamsSectionComponent extends AbstractBaseComponent {
+
+    @Input() parent: Oas20Operation | Oas30Operation | Oas20PathItem | Oas30PathItem;
+    @Input() path: OasPathItem;
+
+    private _headerParameters: (Oas30Parameter | Oas20Parameter)[] = null;
+    private _library: OasLibraryUtils = new OasLibraryUtils();
+
+    public showSectionBody: boolean;
+
+    constructor(private changeDetectorRef: ChangeDetectorRef, private commandService: CommandService,
+                private documentService: DocumentService, private editors: EditorsService,
+                private selectionService: SelectionService) {
+        super(changeDetectorRef, documentService, selectionService);
+    }
+
+    protected onDocumentChange(): void {
+        this._headerParameters = null;
+    }
+
+    public ngOnInit(): void {
+        super.ngOnInit();
+        this.showSectionBody = this.hasHeaderParameters();
+    }
+
+    public ngOnChanges(changes: SimpleChanges): void {
+        super.ngOnChanges(changes);
+        this._headerParameters = null;
+    }
+
+    public isPathItem(): boolean {
+        return this.parent === this.path;
+    }
+
+    public contextHelp(): string {
+        if (this.isPathItem()) {
+            return `
+                Use this section to define HTTP Header Parameters for all of the Operations in this 
+                path.  These header parameters will apply to all operations and can be overridden 
+                (though not removed) at the operation level.`;
+        } else {
+            return `
+                An operation may, optionally, allow additional options to be sent via HTTP header
+                parameters.  This section allows you to document what header parameters are
+                accepted/expected by this operation.`;
+        }
+    }
+
+    public hasParameters(type: string): boolean {
+        if (!this.parent.parameters) {
+            return false;
+        }
+        return this.parent.parameters.filter((value) => {
+            return value.in === type;
+        }).length > 0;
+    }
+
+    public hasHeaderParameters(): boolean {
+        return this.parent.getParameters("header").length > 0 || this.path.getParameters("header").length > 0;
+    }
+
+    public parameters(paramType: string): (Oas30Parameter | Oas20Parameter)[] {
+        let params: (Oas30Parameter | Oas20Parameter)[] = this.parent.getParameters(paramType) as (Oas30Parameter | Oas20Parameter)[];
+        return params.sort((param1, param2) => {
+            return param1.name.localeCompare(param2.name);
+        });
+    }
+
+    public headerParameters(): (Oas30Parameter | Oas20Parameter)[] {
+        if (this.isPathItem()) {
+            return this.parameters("header");
+        }
+
+        if (this._headerParameters !== null) {
+            return this._headerParameters;
+        }
+
+        let opParams: (Oas30Parameter | Oas20Parameter)[] = this.parameters("header");
+        let piParams: (Oas30Parameter | Oas20Parameter)[] = this.path.getParameters("header") as (Oas30Parameter | Oas20Parameter)[];
+        let hasOpParam = function(param: Oas30Parameter | Oas20Parameter): boolean {
+            var found: boolean = false;
+            opParams.forEach( opParam => {
+                if (opParam.name === param.name) {
+                    found = true;
+                }
+            });
+            return found;
+        };
+        piParams.forEach( param => {
+            if (!hasOpParam(param)) {
+                let missingParam: Oas30Parameter | Oas20Parameter = this.parent.createParameter();
+                this._library.readNode(this._library.writeNode(param), missingParam);
+                missingParam.n_attribute("missing", true);
+                opParams.push(missingParam);
+            }
+        });
+        this._headerParameters = opParams.sort((param1, param2) => {
+            return param1.name.localeCompare(param2.name);
+        });
+        return this._headerParameters;
+    }
+
+    public openAddHeaderParamEditor(): void {
+        let editor: ParameterEditorComponent = this.editors.getParameterEditor();
+        editor.setParamType("header");
+        let handler: IParameterEditorHandler = {
+            onSave: (event) => {
+                this.addHeaderParam(event.data);
+            },
+            onCancel: () => {}
+        };
+        editor.open(handler, this.parent);
+    }
+
+    public deleteAllHeaderParams(): void {
+        let command: ICommand = createDeleteAllParametersCommand(this.parent.ownerDocument(), this.parent, "header");
+        this.commandService.emit(command);
+    }
+
+    public deleteParam(parameter: Oas30Parameter | Oas20Parameter): void {
+        let command: ICommand = createDeleteParameterCommand(this.parent.ownerDocument(), parameter);
+        this.commandService.emit(command);
+    }
+
+    public addHeaderParam(data: ParameterData): void {
+        let command: ICommand = createNewParamCommand(this.parent.ownerDocument(), this.parent, data.name,
+            "header", data.description, data.type);
+        this.commandService.emit(command);
+    }
+
+}


### PR DESCRIPTION
This one is for issue #172 . Adding oai-ts-commands seems not necessary.
With this set of changes, you can have:
* local (operation) definition of header param
<img width="925" alt="operation-header" src="https://user-images.githubusercontent.com/1538635/50227387-ebad4880-03a5-11e9-9ca5-da8c0404b968.png">
* global (path) definition of header param
<img width="937" alt="path-header" src="https://user-images.githubusercontent.com/1538635/50227421-fbc52800-03a5-11e9-88b6-aabc8d883de7.png">
* correct JSON/YAML generation of header params
<img width="571" alt="json-view" src="https://user-images.githubusercontent.com/1538635/50227445-0a134400-03a6-11e9-9c49-caa67668f839.png">

