### PR TITLE
Mock with Microcks action support

### DIFF
--- a/back-end/hub-api/src/main/java/io/apicurio/hub/api/microcks/IMicrocksConnector.java
+++ b/back-end/hub-api/src/main/java/io/apicurio/hub/api/microcks/IMicrocksConnector.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.hub.api.microcks;
+
+import java.util.Collection;
+
+/**
+ * A Microcks specific connector.
+ * @author laurent.broudoux@gmail.com
+ */
+public interface IMicrocksConnector {
+
+   /**
+    * Upload an OAS v3 specification content to Microcks. This will trigger service discovery and mock
+    * endpoint publication on the Microcks side.
+    * @param content OAS v3 specification content
+    * @throws MicrocksConnectorException if upload fails for any reasons
+    */
+   public String uploadResourceContent(String content) throws MicrocksConnectorException;
+
+   /**
+    * Reserved for future usage.
+    * @return List of repository secrets managed by Microcks server
+    * @throws MicrocksConnectorException if connection fails for any reasons
+    */
+   public Collection<MicrocksSecret> getSecrets() throws MicrocksConnectorException;
+
+   /**
+    * Reserved for future usage.
+    * @return List of import jobs managed by Microcks server
+    * @throws MicrocksConnectorException if connection fails for any reasons
+    */
+   public Collection<MicrocksImporter> getImportJobs() throws MicrocksConnectorException;
+
+   /**
+    * Reserved for future usage.
+    * @param job Import job to create in Microcks server.
+    * @throws MicrocksConnectorException if connection fails for any reasons
+    */
+   public void createImportJob(MicrocksImporter job) throws MicrocksConnectorException;
+
+   /**
+    * Reserved for future usage.
+    * @param job Import job to force import in Microcks server.
+    * @throws MicrocksConnectorException if connection fails for any reasons
+    */
+   public void forceResourceImport(MicrocksImporter job) throws MicrocksConnectorException;
+}

--- a/back-end/hub-api/src/main/java/io/apicurio/hub/api/microcks/MicrocksConnector.java
+++ b/back-end/hub-api/src/main/java/io/apicurio/hub/api/microcks/MicrocksConnector.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2019 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.hub.api.microcks;
+
+import com.mashape.unirest.http.HttpResponse;
+import com.mashape.unirest.http.JsonNode;
+import com.mashape.unirest.http.Unirest;
+import com.mashape.unirest.http.exceptions.UnirestException;
+import com.mashape.unirest.request.HttpRequestWithBody;
+import com.mashape.unirest.request.body.MultipartBody;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.util.Collection;
+
+/**
+ * Default implementation of a Microcks specific connector.
+ * @author laurent.broudoux@gmail.com
+ */
+public class MicrocksConnector implements IMicrocksConnector {
+
+   private static Logger logger = LoggerFactory.getLogger(MicrocksConnector.class);
+
+   /** Microcks API URL (should ends with /api). */
+   private String apiURL;
+   /** Keycloak URL including realm name (deduced from Microcks configuration). */
+   private String keycloakURL;
+   /** OAuth token associated to this connection. */
+   private String oauthToken;
+
+   /**
+    * Create a new connector for interacting with Microcks.
+    * @param microcksURL Microcks API URL (should ends with /api)
+    * @param keycloakClientId ClientId known from keycloak Microcks realm
+    * @param keycloakClientSecret ClientSecret known from keycloak Microcks realm
+    * @throws MicrocksConnectorException if connection fails for many reasons
+    */
+   public MicrocksConnector(String microcksURL, String keycloakClientId, String keycloakClientSecret) throws MicrocksConnectorException {
+
+      // Store and sanitize microcks API URL.
+      this.apiURL = microcksURL;
+      if (!this.apiURL.endsWith("/api")) {
+         this.apiURL += "/api";
+      }
+
+      // Retrieve the Keycloak configuration to build keycloakURL.
+      HttpResponse<JsonNode> keycloakConfig = null;
+      try {
+         keycloakConfig = Unirest.get(this.apiURL + "/keycloak/config")
+               .header("Accept", "application/json").asJson();
+      } catch (UnirestException e) {
+         logger.error("Exception while connecting to Microcks backend", e);
+         throw new MicrocksConnectorException("Exception while connecting Microcks backend. Check URL.");
+      }
+
+      if (keycloakConfig.getStatus() != 200) {
+         logger.error("Keycloak config cannot be fetched from Microcks server, check configuration");
+         throw new MicrocksConnectorException("Keycloak configuration cannot be fetched from Microcks. Check URL.");
+      }
+      String authServer = keycloakConfig.getBody().getObject().getString("auth-server-url");
+      String realmName = keycloakConfig.getBody().getObject().getString("realm");
+      this.keycloakURL = authServer + "/realms/" + realmName;
+
+      // Retrieve a token using client_credentials flow.
+      HttpRequestWithBody tokenRequest = Unirest.post(this.keycloakURL + "/protocol/openid-connect/token")
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .header("Accept", "application/json")
+            .basicAuth(keycloakClientId, keycloakClientSecret);
+
+      HttpResponse<JsonNode> tokenResponse = null;
+      try {
+         tokenResponse = tokenRequest.body("grant_type=client_credentials").asJson();
+      } catch (UnirestException e) {
+         logger.error("Exception while connecting to Keycloak backend", e);
+         throw new MicrocksConnectorException("Exception while connecting Microcks Keycloak backend. Check Keycloak configuration.");
+      }
+
+      if (tokenResponse.getStatus() != 200) {
+         logger.error("OAuth token cannot be retrieved for Microcks server, check keycloakClient configuration");
+         throw new MicrocksConnectorException("OAuth token cannot be retrieved for Microcks. Check keycloakClient.");
+      }
+      this.oauthToken = tokenResponse.getBody().getObject().getString("access_token");
+   }
+
+   /**
+    * Upload an OAS v3 specification content to Microcks. This will trigger service discovery and mock
+    * endpoint publication on the Microcks side.
+    * @param content OAS v3 specification content
+    * @throws MicrocksConnectorException if upload fails for many reasons
+    */
+   public String uploadResourceContent(String content) throws MicrocksConnectorException {
+
+      MultipartBody uploadRequest = Unirest.post(this.apiURL + "/artifact/upload")
+            .header("Authorization", "Bearer " + oauthToken)
+            .field("file", new ByteArrayInputStream(content.getBytes()), "open-api-contract.yml");
+
+      HttpResponse<String> response = null;
+      try {
+         response = uploadRequest.asString();
+      } catch (UnirestException e) {
+         logger.error("Exception while connecting to Microcks backend", e);
+         throw new MicrocksConnectorException("Exception while connecting Microcks backend. Check URL.");
+      }
+
+      switch (response.getStatus()) {
+         case 201:
+            String serviceRef = response.getBody();
+            logger.info("Microcks mocks have been created/updated for " + serviceRef);
+            return serviceRef;
+         case 204:
+            logger.warn("NoContent returned by Microcks server");
+            throw new MicrocksConnectorException("NoContent returned by Microcks server is unexpected return");
+         case 400:
+            logger.error("ClientRequestMalformed returned by Microcks server: " + response.getStatusText());
+            throw new MicrocksConnectorException("ClientRequestMalformed returned by Microcks server");
+         case 500:
+            logger.error("InternalServerError returned by Microcks server");
+            throw new MicrocksConnectorException("InternalServerError returned by Microcks server");
+         default:
+            logger.error("Unexpected response from Microcks server: " + response.getStatusText());
+            throw new MicrocksConnectorException("Unexpected response by Microcks server: " + response.getStatusText());
+      }
+   }
+
+   /**
+    * Reserved for future usage.
+    * @return List of repository secrets managed by Microcks server
+    * @throws MicrocksConnectorException if connection fails for any reasons
+    */
+   public Collection<MicrocksSecret> getSecrets() throws MicrocksConnectorException {
+      return null;
+   }
+
+   /**
+    * Reserved for future usage.
+    * @return List of import jobs managed by Microcks server
+    * @throws MicrocksConnectorException if connection fails for any reasons
+    */
+   public Collection<MicrocksImporter> getImportJobs() throws MicrocksConnectorException {
+      return null;
+   }
+
+   /**
+    * Reserved for future usage.
+    * @param job Import job to create in Microcks server.
+    * @throws MicrocksConnectorException if connection fails for any reasons
+    */
+   public void createImportJob(MicrocksImporter job) throws MicrocksConnectorException {
+      throw new MicrocksConnectorException("Not implemented");
+   }
+
+   /**
+    * Reserved for future usage.
+    * @param job Import job to force import in Microcks server.
+    * @throws MicrocksConnectorException if connection fails for any reasons
+    */
+   public void forceResourceImport(MicrocksImporter job) throws MicrocksConnectorException {
+      throw new MicrocksConnectorException("Not implemented");
+   }
+}

--- a/back-end/hub-api/src/main/java/io/apicurio/hub/api/microcks/MicrocksConnectorException.java
+++ b/back-end/hub-api/src/main/java/io/apicurio/hub/api/microcks/MicrocksConnectorException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.hub.api.microcks;
+
+/**
+ * Exception related to Microcks backend connnection.
+ * @author laurent.broudoux@gmail.com
+ */
+public class MicrocksConnectorException extends Exception {
+
+   /**
+    * Cerate a MicrocksConnectorException with text message
+    * @param message This exception text message
+    */
+   public MicrocksConnectorException(String message) {
+      super(message);
+   }
+}

--- a/back-end/hub-api/src/main/java/io/apicurio/hub/api/microcks/MicrocksImporter.java
+++ b/back-end/hub-api/src/main/java/io/apicurio/hub/api/microcks/MicrocksImporter.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2018 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.hub.api.microcks;
+
+import java.util.Date;
+
+/**
+ * A Microcks importer.
+ * @author laurent.broudoux@gmail.com
+ */
+public class MicrocksImporter {
+
+   private String id;
+   private String name;
+   private String repositoryUrl;
+   private boolean repositoryDisableSSLValidation = false;
+   private String frequency;
+   private Date createdDate;
+   private Date lastImportDate;
+   private String lastImportError;
+   private boolean active = false;
+   private String etag;
+
+   private MicrocksSecretRef secretRef;
+
+
+   public String getId() {
+      return id;
+   }
+
+   public void setId(String id) {
+      this.id = id;
+   }
+
+   public String getName() {
+      return name;
+   }
+
+   public void setName(String name) {
+      this.name = name;
+   }
+
+   public String getRepositoryUrl() {
+      return repositoryUrl;
+   }
+
+   public void setRepositoryUrl(String repositoryUrl) {
+      this.repositoryUrl = repositoryUrl;
+   }
+
+   public boolean isRepositoryDisableSSLValidation() {
+      return repositoryDisableSSLValidation;
+   }
+
+   public void setRepositoryDisableSSLValidation(boolean repositoryDisableSSLValidation) {
+      this.repositoryDisableSSLValidation = repositoryDisableSSLValidation;
+   }
+
+   public String getFrequency() {
+      return frequency;
+   }
+
+   public void setFrequency(String frequency) {
+      this.frequency = frequency;
+   }
+
+   public Date getCreatedDate() {
+      return createdDate;
+   }
+
+   public void setCreatedDate(Date createdDate) {
+      this.createdDate = createdDate;
+   }
+
+   public Date getLastImportDate() {
+      return lastImportDate;
+   }
+
+   public void setLastImportDate(Date lastImportDate) {
+      this.lastImportDate = lastImportDate;
+   }
+
+   public String getLastImportError() {
+      return lastImportError;
+   }
+
+   public void setLastImportError(String lastImportError) {
+      this.lastImportError = lastImportError;
+   }
+
+   public boolean isActive() {
+      return active;
+   }
+
+   public void setActive(boolean active) {
+      this.active = active;
+   }
+
+   public String getEtag() {
+      return etag;
+   }
+
+   public void setEtag(String etag) {
+      this.etag = etag;
+   }
+
+   public MicrocksSecretRef getSecretRef() {
+      return secretRef;
+   }
+
+   public void setSecretRef(MicrocksSecretRef secretRef) {
+      this.secretRef = secretRef;
+   }
+}

--- a/back-end/hub-api/src/main/java/io/apicurio/hub/api/microcks/MicrocksSecret.java
+++ b/back-end/hub-api/src/main/java/io/apicurio/hub/api/microcks/MicrocksSecret.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2018 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.hub.api.microcks;
+
+/**
+ * A Microcks secret for connecting to repository.
+ * @author laurent.broudoux@gmail.com
+ */
+
+public class MicrocksSecret {
+
+   private String id;
+   private String name;
+   private String description;
+
+   private String username;
+   private String password;
+
+   private String token;
+   private String tokenHeader;
+
+   private String caCertPem;
+
+
+   public String getId() {
+      return id;
+   }
+
+   public void setId(String id) {
+      this.id = id;
+   }
+
+   public String getName() {
+      return name;
+   }
+
+   public void setName(String name) {
+      this.name = name;
+   }
+
+   public String getDescription() {
+      return description;
+   }
+
+   public void setDescription(String description) {
+      this.description = description;
+   }
+
+   public String getUsername() {
+      return username;
+   }
+
+   public void setUsername(String username) {
+      this.username = username;
+   }
+
+   public String getPassword() {
+      return password;
+   }
+
+   public void setPassword(String password) {
+      this.password = password;
+   }
+
+   public String getToken() {
+      return token;
+   }
+
+   public void setToken(String token) {
+      this.token = token;
+   }
+
+   public String getTokenHeader() {
+      return tokenHeader;
+   }
+
+   public void setTokenHeader(String tokenHeader) {
+      this.tokenHeader = tokenHeader;
+   }
+
+   public String getCaCertPem() {
+      return caCertPem;
+   }
+
+   public void setCaCertPem(String caCertPem) {
+      this.caCertPem = caCertPem;
+   }
+}

--- a/back-end/hub-api/src/main/java/io/apicurio/hub/api/microcks/MicrocksSecretRef.java
+++ b/back-end/hub-api/src/main/java/io/apicurio/hub/api/microcks/MicrocksSecretRef.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.hub.api.microcks;
+
+/**
+ * A lightweight reference to a MicrocksSecret object.
+ * @author laurent.broudoux@gmail.com
+ */
+public class MicrocksSecretRef {
+
+   public String secretId;
+   public String name;
+
+   public MicrocksSecretRef() {
+   }
+
+   public MicrocksSecretRef(String secretId, String name) {
+      this.secretId = secretId;
+      this.name = name;
+   }
+
+   public String getSecretId() {
+      return secretId;
+   }
+
+   public void setSecretId(String secretId) {
+      this.secretId = secretId;
+   }
+
+   public String getName() {
+      return name;
+   }
+
+   public void setName(String name) {
+      this.name = name;
+   }
+}

--- a/back-end/hub-api/src/main/java/io/apicurio/hub/api/rest/IDesignsResource.java
+++ b/back-end/hub-api/src/main/java/io/apicurio/hub/api/rest/IDesignsResource.java
@@ -101,6 +101,11 @@ public interface IDesignsResource {
     @Path("{designId}/publications")
     public void publishApi(@PathParam("designId") String designId, NewApiPublication info) throws ServerError, NotFoundException;
 
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("{designId}/publications/mock")
+    public Response publishApiMock(@PathParam("designId") String designId) throws ServerError, NotFoundException;
+
     @GET
     @Produces({ MediaType.APPLICATION_JSON, "application/x-yaml" })
     @Path("{designId}/content")

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/beans/ApiContentType.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/beans/ApiContentType.java
@@ -21,7 +21,7 @@ package io.apicurio.hub.core.beans;
  */
 public enum ApiContentType {
     
-    Document(0), Command(1), Publish(2);
+    Document(0), Command(1), Publish(2), Mock(3);
 
     private final int id;
     
@@ -52,6 +52,9 @@ public enum ApiContentType {
         }
         if (id == 2) {
             return Publish;
+        }
+        if (id == 3) {
+            return Mock;
         }
         return null;
     }

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/config/HubConfiguration.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/config/HubConfiguration.java
@@ -56,6 +56,16 @@ public class HubConfiguration extends Configuration {
     private static final String BITBUCKET_API_URL_ENV = "APICURIO_BITBUCKET_API_URL";
     private static final String BITBUCKET_API_URL_SYSPROP = "apicurio.hub.bitbucket.api";
 
+    private static final String MICROCKS_API_URL_ENV = "APICURIO_MICROCKS_API_URL";
+    private static final String MICROCKS_API_URL_SYSPROP = "apicurio.hub.microcks.api";
+
+    private static final String MICROCKS_CLIENT_ID_ENV = "APICURIO_MICROCKS_CLIENT_ID";
+    private static final String MICROCKS_CLIENT_ID_SYSPROP = "apicurio.hub.microcks.clientId";
+
+    private static final String MICROCKS_CLIENT_SECRET_ENV = "APICURIO_MICROCKS_CLIENT_SECRET";
+    private static final String MICROCKS_CLIENT_SECRET_SYSPROP = "apicurio.hub.microcks.clientSecret";
+
+
     /**
      * @return the configured JDBC type (default: h2)
      */
@@ -125,5 +135,25 @@ public class HubConfiguration extends Configuration {
     public String getBitbucketApiUrl() {
         return getConfigurationProperty(BITBUCKET_API_URL_ENV, BITBUCKET_API_URL_SYSPROP, "https://api.bitbucket.org/2.0");
     }
-    
+
+    /**
+     * @return the configured Microcks API URL
+     */
+    public String getMicrocksApiUrl() {
+        return getConfigurationProperty(MICROCKS_API_URL_ENV, MICROCKS_API_URL_SYSPROP, null);
+    }
+
+    /**
+     * @return the configured Microcks ClientId
+     */
+    public String getMicrocksClientId() {
+        return getConfigurationProperty(MICROCKS_CLIENT_ID_ENV, MICROCKS_CLIENT_ID_SYSPROP, null);
+    }
+
+    /**
+     * @return the configured Microcks ClientSecret
+     */
+    public String getMicrocksClientSecret() {
+        return getConfigurationProperty(MICROCKS_CLIENT_SECRET_ENV, MICROCKS_CLIENT_SECRET_SYSPROP, null);
+    }
 }

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/storage/jdbc/CommonSqlStatements.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/storage/jdbc/CommonSqlStatements.java
@@ -422,7 +422,7 @@ public abstract class CommonSqlStatements implements ISqlStatements {
         		+ "FROM api_content c "
                 + "JOIN api_designs d ON d.id = c.design_id "
         		+ "WHERE c.design_id = ? "
-        		+ "  AND (c.type = 1 OR c.type = 2) "
+        		+ "  AND (c.type = 1 OR c.type = 2 OR c.type = 3) "
         		+ "  AND c.reverted = 0 "
         		+ "ORDER BY created_on DESC LIMIT ? OFFSET ?";
     }
@@ -433,7 +433,7 @@ public abstract class CommonSqlStatements implements ISqlStatements {
         		+ "FROM api_content c "
                 + "JOIN api_designs d ON d.id = c.design_id "
         		+ "WHERE c.created_by = ? "
-        		+ "  AND (c.type = 1 OR c.type = 2) "
+        		+ "  AND (c.type = 1 OR c.type = 2 OR c.type = 3) "
         		+ "  AND c.reverted = 0 "
         		+ "ORDER BY created_on DESC LIMIT ? OFFSET ?";
     }

--- a/front-end/studio/src/app/app-routing.module.ts
+++ b/front-end/studio/src/app/app-routing.module.ts
@@ -32,6 +32,7 @@ import {ApiAcceptPageComponent} from './pages/apis/{apiId}/collaboration/accept/
 import {ApiEditorPageComponent} from './pages/apis/{apiId}/editor/api-editor.page';
 import {PublishPageComponent} from "./pages/apis/{apiId}/publish/publish.page";
 import {CopyPageComponent} from './pages/apis/{apiId}/copy/copy.page';
+import {MockPageComponent} from './pages/apis/{apiId}/mock/mock.page';
 import {DefaultPageComponent} from "./pages/default.page";
 
 const routes: Routes = [
@@ -98,6 +99,11 @@ const routes: Routes = [
     {
         path: "apis/:apiId/copy",
         component: CopyPageComponent,
+        canActivate: [AuthenticationCanActivateGuard]
+    },
+    {
+        path: "apis/:apiId/mock",
+        component: MockPageComponent,
         canActivate: [AuthenticationCanActivateGuard]
     },
     {

--- a/front-end/studio/src/app/app.module.ts
+++ b/front-end/studio/src/app/app.module.ts
@@ -65,6 +65,7 @@ import {ActivityItemComponent} from "./components/common/activity-item.component
 import {EditorDisconnectedDialogComponent} from './pages/apis/{apiId}/editor/_components/dialogs/editor-disconnected.component';
 import {TemplateService} from './services/template.service';
 import {CopyPageComponent} from './pages/apis/{apiId}/copy/copy.page';
+import {MockPageComponent} from './pages/apis/{apiId}/mock/mock.page';
 import {DefaultPageComponent} from "./pages/default.page";
 import {ClipboardModule} from "ngx-clipboard";
 import {InvitationDialogComponent} from "./pages/apis/{apiId}/collaboration/_components/invitation.component";
@@ -82,7 +83,8 @@ import {InvitationDialogComponent} from "./pages/apis/{apiId}/collaboration/_com
         ImportApiFormComponent, CreateApiFormComponent, ApisListComponent, ApisCardsComponent, CopyPageComponent,
         ApiCollaborationPageComponent, ApiAcceptPageComponent, ApiDetailPageComponent, ApiEditorPageComponent,
         PublishPageComponent, GitHubResourceComponent, GitLabResourceComponent, BitbucketResourceComponent,
-        GenerateProjectWizardComponent, ActivityItemComponent, EditorDisconnectedDialogComponent, DefaultPageComponent
+        GenerateProjectWizardComponent, ActivityItemComponent, EditorDisconnectedDialogComponent, MockPageComponent,
+        DefaultPageComponent
 
     ],
     providers: [

--- a/front-end/studio/src/app/components/common/activity-item.component.ts
+++ b/front-end/studio/src/app/components/common/activity-item.component.ts
@@ -17,6 +17,7 @@
 
 import {Component, Input} from "@angular/core";
 import {ApiDesignChange} from "../../models/api-design-change.model";
+import { MockReference } from "../../models/mock-api.model";
 import {ICommand, MarshallUtils} from "oai-ts-commands";
 import {PublishApi} from "../../models/publish-api.model";
 import * as moment from "moment";
@@ -34,6 +35,7 @@ export class ActivityItemComponent {
     @Input() item: ApiDesignChange;
     _command: ICommand = null;
     _publication: PublishApi;
+    _mock: MockReference;
 
     /**
      * Constructor.
@@ -58,6 +60,13 @@ export class ActivityItemComponent {
         return this._publication;
     }
 
+    protected mock(): MockReference {
+        if (this._mock == null) {
+            this._mock = JSON.parse(this.item.data);
+        }
+        return this._mock;
+    }
+
     /**
      * Returns an appropriate icon for the activity item, based on its type.
      * 
@@ -68,6 +77,9 @@ export class ActivityItemComponent {
         }
         if (this.item.type == "Publish") {
             return this.publicationIcon();
+        }
+        if (this.item.type == "Mock") {
+            return this.mockIcon();
         }
         return "document";
     }
@@ -226,6 +238,10 @@ export class ActivityItemComponent {
         return this.publication().type.toLowerCase();
     }
 
+    protected mockIcon(): string {
+        return "cloud-upload";
+    }
+
     /**
      * Returns an appropriate description for the activity item, based on its type.
      * 
@@ -236,6 +252,9 @@ export class ActivityItemComponent {
         }
         if (this.item.type == "Publish") {
             return this.publicationDescription();
+        }
+        if (this.item.type == "Mock") {
+            return this.mockDescription();
         }
         return null;
     }
@@ -511,6 +530,11 @@ export class ActivityItemComponent {
 
     protected publicationDescription(): string {
         return "published the API to " + this.publication().type + ".";
+    }
+
+    protected mockDescription(): string {
+        return "mock the API to " + this.mock().serviceRef 
+            + " at " + this.mock().mockURL + ".";
     }
 
     public apiName(): string {

--- a/front-end/studio/src/app/models/mock-api.model.ts
+++ b/front-end/studio/src/app/models/mock-api.model.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class MockReference {
+    
+    serviceRef: string;
+    mockURL: string;
+}

--- a/front-end/studio/src/app/pages/apis/{apiId}/api-detail.page.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/api-detail.page.html
@@ -58,6 +58,12 @@
                                                         <span>Publish...</span>
                                                     </a>
                                                 </li>
+                                                <li>
+                                                    <a [routerLink]="[ 'mock' ]">
+                                                        <span class="fa fa-fw fa-cloud-upload"></span>
+                                                        <span>Mock with Microcks...</span>
+                                                    </a>
+                                                </li>
                                                 <li role="separator" class="divider"></li>
                                                 <li>
                                                     <a href="download?type=api&format=yaml&id={{ api.id }}" download="{{ api.name }}.yaml">

--- a/front-end/studio/src/app/pages/apis/{apiId}/mock/mock.page.css
+++ b/front-end/studio/src/app/pages/apis/{apiId}/mock/mock.page.css
@@ -1,0 +1,26 @@
+.api-mock {
+}
+
+.api-mock .mockapi-form {
+  margin-top: 20px;
+}
+
+.api-mock .mockapi-form .mockapi-panel {
+}
+
+.api-mock .mockapi-form h2 {
+  margin-top: 10px;
+  margin-bottom: 25px;
+}
+
+.api-mock .mockapi-form .control-label {
+  padding-right: 0px;
+}
+
+hr {
+  margin-top: 5px;
+}
+
+.api-mock .notice-of-required {
+  margin-top: 30px;
+}

--- a/front-end/studio/src/app/pages/apis/{apiId}/mock/mock.page.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/mock/mock.page.html
@@ -1,0 +1,83 @@
+<div id="api-breadcrumb-bar">
+    <breadcrumbs>
+        <li breadcrumb label="APIs" [route]="[ '/apis' ]"></li>
+        <li breadcrumb [label]="api.name" [route]="[ '/apis', api.id ]"></li>
+        <li breadcrumb label="Mock" class="active"></li>
+    </breadcrumbs>
+</div>
+<page-error [error]="pageError" *ngIf="pageError"></page-error>
+<div class="container-fluid api-mock" *ngIf="!pageError">
+
+    <!-- Loading API (spinner) -->
+    <div class="row-fluid" *ngIf="!isDataLoaded()">
+        <div class="col-xs-12 col-sm-6 col-md-6">
+            <div class="container-fluid container-cards-pf api-editor-overview">
+                <div class="row row-cards-pf">
+                    <div class="">
+                        <div class="card-pf card-pf-accented">
+                            <div class="card-pf-heading">
+                                <h1 class="card-pf-title">
+                                    <p><span class="spinner spinner-xs spinner-inline"></span> Loading API information...</p>
+                                </h1>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="mockapi-form row" *ngIf="isDataLoaded()">
+        <div class="form-instructions col-md-3">
+            <div class="alert alert-info">
+                <span class="pficon pficon-info"></span>
+                <strong>What is this page?</strong>
+                <p style="line-height: 18px">
+                    Use this page to create or update mocks from your API. If the API is using OpenAPI 3.0 format and you have a Microcks 
+                    instance configured, you may choose to publish once or create an importing job.
+                </p>
+            </div>
+        </div>
+        <div class="col-md-7">
+            <div class="mockapi-panel panel panel-default">
+                <div class="panel-body" *ngIf="!mocked">
+                    <h2>Publish mock for API "{{ api.name }}"?</h2>
+
+                    <div class="notice-of-required">The fields marked with <span class="required-icon">*</span> are required.</div>
+                    <hr />
+
+                    <form id="mock-form" class="form-horizontal" (submit)="mockApi()" #publishForm="ngForm">
+
+                        <div class="form-group" >
+                            <div class="col-sm-offset-2 col-sm-10">
+                                <button type="submit" class="btn btn-primary pull-right" [disabled]="!isValid() || mocking">
+                                    <span *ngIf="!mocking">Mock API</span>
+                                    <span *ngIf="mocking"><span class="spinner spinner-xs spinner-inline"></span> Mocking...</span>
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+            <div class="panel-body" *ngIf="mocked">
+                <div class="blank-slate-pf " id="">
+                    <div class="blank-slate-pf-icon">
+                        <span class="pficon pficon pficon-add-circle-o"></span>
+                    </div>
+                    <h1>API Mocked Successfully</h1>
+                    <p>
+                        Your API <strong>{{ api.name }}</strong> has been successfully mocked to Microcks server.  No additional
+                        steps need to be taken.
+                    </p>
+                    <p>
+                        Service Reference: <a href="{{ mockReference.mockURL }}" target="external">{{ mockReference.serviceRef }}</a>
+                    </p>
+                    <div class="blank-slate-pf-main-action">
+                        <a [routerLink]="[ '/apis', api.id ]" class="btn btn-primary btn-lg">OK</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/front-end/studio/src/app/pages/apis/{apiId}/mock/mock.page.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/mock/mock.page.ts
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2018 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Component} from "@angular/core";
+import {ActivatedRoute, Router} from "@angular/router";
+
+import {ApiDefinition} from "../../../../models/api.model";
+import {MockReference} from "../../../../models/mock-api.model";
+import {AbstractPageComponent} from "../../../../components/page-base.component";
+import {Title} from "@angular/platform-browser";
+import {ApisService} from "../../../../services/apis.service";
+import {OasDocument, OasLibraryUtils} from "oai-ts-core";
+
+
+@Component({
+    moduleId: module.id,
+    selector: "mock-page",
+    templateUrl: "mock.page.html",
+    styleUrls: ["mock.page.css"]
+})
+export class MockPageComponent extends AbstractPageComponent {
+
+    public api: ApiDefinition;
+    public document: OasDocument;
+
+    public modelValid: any;
+    public mockReference: MockReference;
+
+    public mocking: boolean = false;
+    public mocked: boolean = false;
+
+    /**
+     * Constructor.
+     * @param router
+     * @param route
+     * @param apis
+     * @param titleService
+     */
+    constructor(private router: Router, route: ActivatedRoute, private apis: ApisService, protected titleService: Title) {
+        super(route, titleService);
+        this.api = new ApiDefinition();
+        this.api.name = "API";
+    }
+
+    /**
+     * The page title.
+     */
+    protected pageTitle(): string {
+        if (this.api.name) {
+            return "Apicurio Studio - Mock API :: " + this.api.name;
+        } else {
+            return "Apicurio Studio - Mock API";
+        }
+    }
+
+    /**
+     * Called to kick off loading the page's async data.
+     * @param params
+     */
+    public loadAsyncPageData(params: any): void {
+        console.info("[MockPageComponent] Loading async page data");
+        let apiId: string = params["apiId"];
+        this.apis.getApiDefinition(apiId).then(api => {
+            this.api = api;
+            this.document = new OasLibraryUtils().createDocument(this.api.spec);
+            this.dataLoaded["api"] = true;
+            this.updatePageTitle();
+        }).catch(error => {
+            console.error("[MockPageComponent] Error getting API def");
+            this.error(error);
+        });
+    }
+
+    public isDataLoaded(): boolean {
+        return this.isLoaded("api");
+    }
+
+    public isValid(): boolean {
+        return this.document != null;
+    }
+
+    public mockApi(): void {
+        if (!this.isValid) {
+            return;
+        }
+
+        this.mocking = true;
+
+        this.apis.publishApiMock(this.api.id).then( (reference) => {
+            console.log("[MockPageComponent] Published mock with serviceReference: " + reference.serviceRef);
+            this.mocking = false;
+            this.mocked = true;
+            this.mockReference = reference;
+        }).catch( error => {
+            this.mocking = false;
+            this.error(error);
+        });
+    }
+}

--- a/front-end/studio/src/app/services/apis.service.ts
+++ b/front-end/studio/src/app/services/apis.service.ts
@@ -38,6 +38,7 @@ import {UpdateCodegenProject} from "../models/update-codegen-project.model";
 import {Injectable} from "@angular/core";
 import {ApiPublication} from "../models/api-publication.model";
 import {UpdateCollaborator} from "../models/update-collaborator.model";
+import {MockReference} from "../models/mock-api.model";
 
 
 export interface IConnectionHandler {
@@ -406,6 +407,21 @@ export class ApisService extends AbstractHubService {
 
         console.info("[ApisService] Publishing an API Design: %s", publishApiUrl);
         return this.httpPost<PublishApi>(publishApiUrl, info, options);
+    }
+
+    /**
+     * @see ApisService.publishApiMock
+     */
+    public publishApiMock(apiId: string): Promise<MockReference> {
+        console.info("[ApisService] Publishing an API mock via the hub API");
+
+        let publishMockApiUrl: string = this.endpoint("/designs/:designId/publications/mock", {
+            designId: apiId
+        });
+        let options: any = this.options({ "Content-Type": "application/json" });
+        
+        console.info("[ApisService] Publishing an API mock: %s", publishMockApiUrl);
+        return this.httpPostWithReturn<Object, MockReference>(publishMockApiUrl, {}, options);
     }
 
     /**


### PR DESCRIPTION
This is for #369 ;-) 
Within this commit:
* Adding new MicrocksConnector configured with HubConfig
* Adding new API on back-end with front-end client API
* Adding front-end action menu
* Adding persistence of api_content for each mock publication
* Adding activity into API feed on summary page