### PR TITLE
Adding parameters examples management

### DIFF
--- a/front-end/studio/src/app/components/common/activity-item.component.ts
+++ b/front-end/studio/src/app/components/common/activity-item.component.ts
@@ -95,6 +95,7 @@ export class ActivityItemComponent {
             case "AddSchemaDefinitionCommand_30":
             case "AddSecurityRequirementCommand":
             case "AddExampleCommand_30":
+            case "AddParameterExampleCommand_30":
                 rval = "plus";
                 break;
             case "ChangeContactCommand":
@@ -144,6 +145,7 @@ export class ActivityItemComponent {
             case "SetExampleCommand":
             case "SetExampleCommand_20":
             case "SetExampleCommand_30":
+            case "SetParameterExampleCommand_30":
             case "SetExtensionCommand":
             case "ReplaceSecurityRequirementCommand":
                 rval = "pencil";
@@ -198,6 +200,7 @@ export class ActivityItemComponent {
             case "DeleteExampleCommand":
             case "DeleteExampleCommand_20":
             case "DeleteExampleCommand_30":
+            case "DeleteParameterExampleCommand_30":
             case "DeleteExtensionCommand":
                 rval = "trash-o";
                 break;
@@ -577,11 +580,17 @@ export class ActivityItemComponent {
             case "AddExampleCommand_30":
                 rval = "added an example named '" + this.command()["_newExampleName"] + "' to the MediaType at location " + this.command()["_parentPath"] + ".";
                 break;
+            case "AddParameterExampleCommand_30":
+                rval = "added an example named '" + this.command()["_newExampleName"] + "' to the Parameter at location " + this.command()["_parentPath"] + ".";
+                break;
             case "SetExampleCommand_20":
                 rval = "changed the value of the example for content-type '" + this.command()["_newContentType"] + "' for the Response at location " + this.command()["_parentPath"] + ".";
                 break;
             case "SetExampleCommand_30":
                 rval = "changed the value of the example named '" + this.command()["_newExampleName"] + "' for the MediaType at location " + this.command()["_parentPath"] + ".";
+                break;
+            case "SetParameterExampleCommand_30":
+                rval = "changed the value of the example named '" + this.command()["_newExampleName"] + "' for the Parameter at location " + this.command()["_parentPath"] + ".";
                 break;
             case "SetExtensionCommand":
                 rval = `changed the value of the extension named '${ this.command()["_name"] }'.`;

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/header-param-row.component.css
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/header-param-row.component.css
@@ -43,7 +43,7 @@
 }
 
 .header-param .header .description {
-  flex-basis: 39%;
+  flex-basis: 28%;
   overflow-x: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -54,7 +54,7 @@
   cursor: pointer;
 }
 .header-param .header .summary {
-  flex-basis: 41%;
+  flex-basis: 27%;
 }
 .header-param .header .summary:hover {
   color: #0088ce;
@@ -66,6 +66,18 @@
 }
 .header-param .header .summary .parameter-required:hover {
   filter: brightness(120%);
+}
+
+.header-param .header .examples {
+  flex-basis: 25%;
+  overflow-x: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding-right: 15px;
+}
+.header-param .header .examples:hover {
+  color: #0088ce;
+  cursor: pointer;
 }
 
 .header-param .header .actions {
@@ -118,6 +130,13 @@
 }
 .header-param .body .param-type {
   margin-bottom: 10px;
+}
+
+.header-param .body .param-examplesform {
+  width: 100%;
+}
+.header-param .body .param-examples .form-label {
+  font-weight: 600;
 }
 
 .header-param .body .param-required .dropdown {

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/header-param-row.component.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/header-param-row.component.html
@@ -19,6 +19,10 @@
             <span class="parameter-required" *ngIf="isRequired()" title="This header parameter is required.">[required]</span>
             <schema-type [type]="displayType()"></schema-type>
         </div>
+        <div class="examples" (click)="toggleExamples()" [class.selected]="isEditingExamples()" *ngIf="is3xDocument()">
+            <span class="fa fa-angle-right" [class.fa-angle-down]="isEditingExamples()"></span>
+            <span [class.empty]="!hasExamples()"> {{ displayExamples() }}</span>
+        </div>
         <div class="actions">
             <div class="dropdown dropdown-kebab-pf" *ngIf="!isOverridable()">
                 <button class="btn btn-link dropdown-toggle" type="button" (click)="$event.preventDefault()"
@@ -59,8 +63,48 @@
                                                 (onChange)="changeType($event)"></schema-type-editor>
                         </div>
                     </div>
+                    <div class="param-examples" *ngIf="isEditingExamples()">
+                        <div class="form-label">Examples</div>
+                        <signpost *ngIf="!hasExamples()">
+                            <span>No examples have been defined.</span>
+                            <a (click)="addExampleDialog.open()">Add an example</a>
+                        </signpost>
+                        <div *ngIf="hasExamples()">
+                            <table class="table table-striped table-bordered table-examples">
+                                <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th class="pre-actions">Example</th>
+                                    <th class="actions"></th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr *ngFor="let example of paramExamples()">
+                                    <td class="name">
+                                        <validation-problem [model]="example"></validation-problem>
+                                        <span>{{ example.getName() }}</span>
+                                    </td>
+                                    <td class="value pre-actions">
+                                        <span>{{ exampleValue(example) }}</span>
+                                    </td>
+                                    <td class="actions">
+                                        <div>
+                                            <icon-button (onClick)="deleteExample(example)" [pullRight]="true" type="delete"
+                                                            [title]="'Delete example.'"></icon-button>
+                                            <icon-button (onClick)="editExampleDialog.open(example)" [pullRight]="true" type="edit"
+                                                            [title]="'Edit example.'"></icon-button>
+                                        </div>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                            <a (click)="addExampleDialog.open()">Add an example</a>
+                        </div>
+                    </div>
                 </div>
             </form>
         </div>
     </div>
+    <add-example-dialog #addExampleDialog (onAdd)="addExample($event)" [schema]="schemaForExample()"></add-example-dialog>
+    <edit-example-dialog #editExampleDialog (onEdit)="editExample($event)" [schema]="schemaForExample()"></edit-example-dialog>
 </div>

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/header-param-row.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/header-param-row.component.ts
@@ -32,13 +32,18 @@ import {
     OasParameter,
     OasPathItem,
     SimplifiedParameterType,
-    SimplifiedType
+    SimplifiedType,
+    OasDocument,
+    Oas30Parameter,
+    Oas30Example,
+    Schema
 } from "apicurio-data-models";
 import {DropDownOption, DropDownOptionValue as Value} from '../../../../../../../components/common/drop-down.component';
 import {CommandService} from "../../../_services/command.service";
 import {DocumentService} from "../../../_services/document.service";
 import {SelectionService} from "../../../_services/selection.service";
 import {AbstractRowComponent} from "../../common/item-row.abstract";
+import { EditExampleEvent } from "../../dialogs/edit-example.component";
 
 @Component({
     moduleId: module.id,
@@ -103,6 +108,29 @@ export class HeaderParamRowComponent extends AbstractRowComponent<OasParameter, 
         }
     }
 
+    public is3xDocument(): boolean {
+        return (<OasDocument> this.item.ownerDocument()).is3xDocument();
+    }
+    
+    public hasExamples(): boolean {
+        if (this.item instanceof Oas30Parameter) {
+            return this.paramExamples().length > 0;
+        }
+        return false;
+    }
+
+    public paramExamples(): Oas30Example[] {
+        return (<Oas30Parameter> this.item).getExamples();
+    }
+
+    public exampleValue(example: Oas30Example): string {
+        let evalue: any = example.value;
+        if (typeof evalue === "object" || Array.isArray(evalue)) {
+            evalue = JSON.stringify(evalue);
+        }
+        return evalue;
+    }
+
     public description(): string {
         return this.item.description
     }
@@ -130,6 +158,10 @@ export class HeaderParamRowComponent extends AbstractRowComponent<OasParameter, 
         return this.isEditingTab("summary");
     }
 
+    public isEditingExamples(): boolean {
+        return this.isEditingTab("examples");
+    }
+
     public toggleDescription(): void {
         if (this.isOverridable()) {
             this._editing = false;
@@ -146,12 +178,28 @@ export class HeaderParamRowComponent extends AbstractRowComponent<OasParameter, 
         this.toggleTab("summary");
     }
 
+    public toggleExamples(): void {
+        if (this.isOverridable() || this.isMissing()) {
+            this._editing = false;
+            return;
+        }
+        this.toggleTab("examples");
+    }
+
     public delete(): void {
         this.onDelete.emit();
     }
 
     public displayType(): SimplifiedParameterType {
         return SimplifiedParameterType.fromParameter(this.item as any);
+    }
+
+    public displayExamples(): string {
+        if (this.hasExamples()) {
+            return `${this.paramExamples().length} example(s) defined.`;
+        } else {
+            return "No examples defined."
+        }
     }
 
     public rename(): void {
@@ -182,6 +230,40 @@ export class HeaderParamRowComponent extends AbstractRowComponent<OasParameter, 
         this._model = nt;
     }
 
+    public addExample(exampleData: any): void {
+        var param = <Oas30Parameter> this.item;
+        let command: ICommand = CommandFactory.createAddParameterExampleCommand(param,
+            exampleData.value, exampleData.name, null, null);
+        this.commandService.emit(command);
+        let nodePath = Library.createNodePath(this.item);
+        nodePath.appendSegment("examples", false);
+        this.__selectionService.select(nodePath.toString());
+    }
+
+    public deleteExample(example: Oas30Example): void {
+        console.info("[HeaderParamRowComponent] Deleting an example of a header parameter.");
+        let command: ICommand = CommandFactory.createDeleteParameterExampleCommand(example);
+        this.commandService.emit(command);
+    }
+
+    public deleteAllExamples(): void {
+        var param = <Oas30Parameter> this.item;
+        let command: ICommand = CommandFactory.createDeleteAllParameterExamplesCommand(param);
+        this.commandService.emit(command);
+    }
+
+    public editExample(event: EditExampleEvent): void {
+        console.info("[HeaderParamRowComponent] Changing the value of a Parameter example.");
+        let command: ICommand = CommandFactory.createSetParameterExampleCommand(this.item,
+            event.value, event.example.getName());
+        this.commandService.emit(command);
+    }
+
+    public schemaForExample(): Schema {
+        var param = <Oas30Parameter> this.item;
+        return param.schema;
+    }
+    
     public override(): void {
         let command: ICommand = CommandFactory.createNewParamCommand(this.item.parent() as any, this.item.name,
             "header", null, null, true);

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/path-param-row.component.css
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/path-param-row.component.css
@@ -51,7 +51,7 @@
 }
 
 .path-parameter .header .description {
-  flex-basis: 39%;
+  flex-basis: 28%;
   overflow-x: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -62,7 +62,7 @@
   cursor: pointer;
 }
 .path-parameter .header .summary {
-  flex-basis: 41%;
+  flex-basis: 27%;
 }
 .path-parameter .header .summary:hover {
   color: #0088ce;
@@ -74,6 +74,18 @@
 }
 .path-parameter .header .summary .parameter-required:hover {
   filter: brightness(120%);
+}
+
+.path-parameter .header .examples {
+  flex-basis: 25%;
+  overflow-x: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding-right: 15px;
+}
+.path-parameter .header .examples:hover {
+  color: #0088ce;
+  cursor: pointer;
 }
 
 .path-parameter .header .actions {
@@ -126,6 +138,13 @@
 }
 .path-parameter .body .param-type {
   margin-bottom: 10px;
+}
+
+.path-parameter .body .param-examplesform {
+  width: 100%;
+}
+.path-parameter .body .param-examples .form-label {
+  font-weight: 600;
 }
 
 .path-parameter .body .param-required .dropdown {

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/path-param-row.component.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/path-param-row.component.html
@@ -21,6 +21,10 @@
             <span class="fa fa-angle-right" [class.fa-angle-down]="isEditingSummary()"></span>
             <schema-type [type]="displayType()"></schema-type>
         </div>
+        <div class="examples" (click)="toggleExamples()" [class.selected]="isEditingExamples()" *ngIf="is3xDocument()">
+            <span class="fa fa-angle-right" [class.fa-angle-down]="isEditingExamples()"></span>
+            <span [class.empty]="!hasExamples()"> {{ displayExamples() }}</span>
+        </div>
         <div class="actions">
             <div class="dropdown dropdown-kebab-pf" *ngIf="!isMissing() && !isOverridable()">
                 <button class="btn btn-link dropdown-toggle" type="button" (click)="$event.preventDefault()"
@@ -54,8 +58,48 @@
                                                 (onChange)="changeType($event)"></schema-type-editor>
                         </div>
                     </div>
+                    <div class="param-examples" *ngIf="isEditingExamples()">
+                        <div class="form-label">Examples</div>
+                        <signpost *ngIf="!hasExamples()">
+                            <span>No examples have been defined.</span>
+                            <a (click)="addExampleDialog.open()">Add an example</a>
+                        </signpost>
+                        <div *ngIf="hasExamples()">
+                            <table class="table table-striped table-bordered table-examples">
+                                <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th class="pre-actions">Example</th>
+                                    <th class="actions"></th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr *ngFor="let example of paramExamples()">
+                                    <td class="name">
+                                        <validation-problem [model]="example"></validation-problem>
+                                        <span>{{ example.getName() }}</span>
+                                    </td>
+                                    <td class="value pre-actions">
+                                        <span>{{ exampleValue(example) }}</span>
+                                    </td>
+                                    <td class="actions">
+                                        <div>
+                                            <icon-button (onClick)="deleteExample(example)" [pullRight]="true" type="delete"
+                                                            [title]="'Delete example.'"></icon-button>
+                                            <icon-button (onClick)="editExampleDialog.open(example)" [pullRight]="true" type="edit"
+                                                            [title]="'Edit example.'"></icon-button>
+                                        </div>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                            <a (click)="addExampleDialog.open()">Add an example</a>
+                        </div>
+                    </div>
                 </div>
             </form>
         </div>
     </div>
+    <add-example-dialog #addExampleDialog (onAdd)="addExample($event)" [schema]="schemaForExample()"></add-example-dialog>
+    <edit-example-dialog #editExampleDialog (onEdit)="editExample($event)" [schema]="schemaForExample()"></edit-example-dialog>
 </div>

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/query-param-row.component.css
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/query-param-row.component.css
@@ -43,7 +43,7 @@
 }
 
 .query-param .header .description {
-  flex-basis: 39%;
+  flex-basis: 28%;
   overflow-x: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -54,7 +54,7 @@
   cursor: pointer;
 }
 .query-param .header .summary {
-  flex-basis: 41%;
+  flex-basis: 27%;
 }
 .query-param .header .summary:hover {
   color: #0088ce;
@@ -66,6 +66,18 @@
 }
 .query-param .header .summary .parameter-required:hover {
   filter: brightness(120%);
+}
+
+.query-param .header .examples {
+  flex-basis: 25%;
+  overflow-x: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding-right: 15px;
+}
+.query-param .header .examples:hover {
+  color: #0088ce;
+  cursor: pointer;
 }
 
 .query-param .header .actions {
@@ -118,6 +130,13 @@
 }
 .query-param .body .param-type {
   margin-bottom: 10px;
+}
+
+.query-param .body .param-examplesform {
+  width: 100%;
+}
+.query-param .body .param-examples .form-label {
+  font-weight: 600;
 }
 
 .query-param .body .param-required .dropdown {

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/query-param-row.component.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/query-param-row.component.html
@@ -19,6 +19,10 @@
             <span class="parameter-required" *ngIf="isRequired()" title="This query parameter is required.">[required]</span>
             <schema-type [type]="displayType()"></schema-type>
         </div>
+        <div class="examples" (click)="toggleExamples()" [class.selected]="isEditingExamples()" *ngIf="is3xDocument()">
+            <span class="fa fa-angle-right" [class.fa-angle-down]="isEditingExamples()"></span>
+            <span [class.empty]="!hasExamples()"> {{ displayExamples() }}</span>
+        </div>
         <div class="actions">
             <div class="dropdown dropdown-kebab-pf" *ngIf="!isOverridable()">
                 <button class="btn btn-link dropdown-toggle" type="button" (click)="$event.preventDefault()"
@@ -59,8 +63,48 @@
                                                 (onChange)="changeType($event)"></schema-type-editor>
                         </div>
                     </div>
+                    <div class="param-examples" *ngIf="isEditingExamples()">
+                        <div class="form-label">Examples</div>
+                        <signpost *ngIf="!hasExamples()">
+                            <span>No examples have been defined.</span>
+                            <a (click)="addExampleDialog.open()">Add an example</a>
+                        </signpost>
+                        <div *ngIf="hasExamples()">
+                            <table class="table table-striped table-bordered table-examples">
+                                <thead>
+                                <tr>
+                                    <th>Name</th>
+                                    <th class="pre-actions">Example</th>
+                                    <th class="actions"></th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr *ngFor="let example of paramExamples()">
+                                    <td class="name">
+                                        <validation-problem [model]="example"></validation-problem>
+                                        <span>{{ example.getName() }}</span>
+                                    </td>
+                                    <td class="value pre-actions">
+                                        <span>{{ exampleValue(example) }}</span>
+                                    </td>
+                                    <td class="actions">
+                                        <div>
+                                            <icon-button (onClick)="deleteExample(example)" [pullRight]="true" type="delete"
+                                                            [title]="'Delete example.'"></icon-button>
+                                            <icon-button (onClick)="editExampleDialog.open(example)" [pullRight]="true" type="edit"
+                                                            [title]="'Edit example.'"></icon-button>
+                                        </div>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                            <a (click)="addExampleDialog.open()">Add an example</a>
+                        </div>
+                    </div>
                 </div>
             </form>
         </div>
     </div>
+    <add-example-dialog #addExampleDialog (onAdd)="addExample($event)" [schema]="schemaForExample()"></add-example-dialog>
+    <edit-example-dialog #editExampleDialog (onEdit)="editExample($event)" [schema]="schemaForExample()"></edit-example-dialog>
 </div>

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/query-param-row.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/query-param-row.component.ts
@@ -31,7 +31,11 @@ import {
     OasParameter,
     OasPathItem,
     SimplifiedParameterType,
-    SimplifiedType
+    SimplifiedType,
+    OasDocument,
+    Oas30Parameter,
+    Oas30Example,
+    Schema
 } from "apicurio-data-models";
 import {DropDownOption, DropDownOptionValue as Value} from '../../../../../../../components/common/drop-down.component';
 import {CommandService} from "../../../_services/command.service";
@@ -39,6 +43,7 @@ import {DocumentService} from "../../../_services/document.service";
 import {SelectionService} from "../../../_services/selection.service";
 import {AbstractRowComponent} from "../../common/item-row.abstract";
 import {AbstractBaseComponent} from "../../common/base-component";
+import { EditExampleEvent } from "../../dialogs/edit-example.component";
 
 
 @Component({
@@ -105,6 +110,29 @@ export class QueryParamRowComponent extends AbstractRowComponent<OasParameter, S
         return this.item.description
     }
 
+    public is3xDocument(): boolean {
+        return (<OasDocument> this.item.ownerDocument()).is3xDocument();
+    }
+    
+    public hasExamples(): boolean {
+        if (this.item instanceof Oas30Parameter) {
+            return this.paramExamples().length > 0;
+        }
+        return false;
+    }
+
+    public paramExamples(): Oas30Example[] {
+        return (<Oas30Parameter> this.item).getExamples();
+    }
+
+    public exampleValue(example: Oas30Example): string {
+        let evalue: any = example.value;
+        if (typeof evalue === "object" || Array.isArray(evalue)) {
+            evalue = JSON.stringify(evalue);
+        }
+        return evalue;
+    }
+
     public isRequired(): boolean {
         return this.item.required;
     }
@@ -128,6 +156,10 @@ export class QueryParamRowComponent extends AbstractRowComponent<OasParameter, S
         return this.isEditingTab("summary");
     }
 
+    public isEditingExamples(): boolean {
+        return this.isEditingTab("examples");
+    }
+
     public toggleDescription(): void {
         if (this.isOverridable()) {
             this._editing = false;
@@ -144,12 +176,28 @@ export class QueryParamRowComponent extends AbstractRowComponent<OasParameter, S
         this.toggleTab("summary");
     }
 
+    public toggleExamples(): void {
+        if (this.isOverridable() || this.isMissing()) {
+            this._editing = false;
+            return;
+        }
+        this.toggleTab("examples");
+    }
+
     public delete(): void {
         this.onDelete.emit();
     }
 
     public displayType(): SimplifiedParameterType {
         return SimplifiedParameterType.fromParameter(this.item as any);
+    }
+
+    public displayExamples(): string {
+        if (this.hasExamples()) {
+            return `${this.paramExamples().length} example(s) defined.`;
+        } else {
+            return "No examples defined."
+        }
     }
 
     public rename(): void {
@@ -180,6 +228,40 @@ export class QueryParamRowComponent extends AbstractRowComponent<OasParameter, S
         this._model = nt;
     }
 
+    public addExample(exampleData: any): void {
+        var param = <Oas30Parameter> this.item;
+        let command: ICommand = CommandFactory.createAddParameterExampleCommand(param,
+            exampleData.value, exampleData.name, null, null);
+        this.commandService.emit(command);
+        let nodePath = Library.createNodePath(this.item);
+        nodePath.appendSegment("examples", false);
+        this.__selectionService.select(nodePath.toString());
+    }
+
+    public deleteExample(example: Oas30Example): void {
+        console.info("[QueryParamRowComponent] Deleting an example of a query parameter.");
+        let command: ICommand = CommandFactory.createDeleteParameterExampleCommand(example);
+        this.commandService.emit(command);
+    }
+
+    public deleteAllExamples(): void {
+        var param = <Oas30Parameter> this.item;
+        let command: ICommand = CommandFactory.createDeleteAllParameterExamplesCommand(param);
+        this.commandService.emit(command);
+    }
+
+    public editExample(event: EditExampleEvent): void {
+        console.info("[QueryParamRowComponent] Changing the value of a Parameter example.");
+        let command: ICommand = CommandFactory.createSetParameterExampleCommand(this.item,
+            event.value, event.example.getName());
+        this.commandService.emit(command);
+    }
+
+    public schemaForExample(): Schema {
+        var param = <Oas30Parameter> this.item;
+        return param.schema;
+    }
+    
     public override(): void {
         let command: ICommand = CommandFactory.createNewParamCommand(this.item.parent() as any,
             this.item.name, "query", null, null, true);

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <version.io.thorntail>2.5.0.Final</version.io.thorntail>
         
         <!-- Apicurio Data Models -->
-        <version.apicurio-data-models>1.0.7.Final</version.apicurio-data-models>
+        <version.apicurio-data-models>1.0.8-SNAPSHOT</version.apicurio-data-models>
 
         <!-- Apache Artemis Version -->
         <version.apache-artemis>2.6.4</version.apache-artemis>


### PR DESCRIPTION
This commit adds examples management for `path`, `query` and `header` parameters.

It requires updating dependencies to `apicurio-data-models:1.0.8-SNAPSHOT` once https://github.com/Apicurio/apicurio-data-models/pull/49 will be accepted and merge (this later PR adds necessary commands for adding/updating/removing example to a parameter).