### PR TITLE
Apicurio 891 - Kubernetes configurations

### DIFF
--- a/distro/kubernetes/README.md
+++ b/distro/kubernetes/README.md
@@ -1,0 +1,93 @@
+# Kubernetes Installation
+
+## Prerequisites
+
+This setup contains all needed configuration items to deploy Apicurio-Studio to a Kubernetes Cluster. Check if you have already prepared all dependencies needed for Installation:
+
+- existing Keycloak Cluster (https://apicurio-studio.readme.io/docs/setting-up-keycloak-for-use-with-apicurio)
+- standard Storageclass for creating Persistent Volumes (Claims)
+- Ingress controller ( only required if used)
+- Microcks Cluster ( only required if the feature is enabled)
+
+## Setup
+
+All configuration variables needed can be found in apicurio-configmap.yaml and apicurio-secrets.yaml.
+
+Clone the git and check out the yaml-configs:
+
+```
+git clone https://github.com/Apicurio/apicurio-studio.git
+cd apicurio-studio/distro/kubernetes
+```
+
+### apicurio-configmap
+
+declare the variables in the following manner:
+```
+  #set your Keycloak URL ending with /auth
+  keycloak-url:  http://keycloak.example.com/auth
+  #set your redirect uri if needed - standard / 
+  apicurio-ui-logout-redirect-uri: /
+  #set the Main-URL ending with /studio-api
+  apicurio-ui-hub-api-url: http://my-apicurio-studio.com/studio-api
+  #set the Main URL ending with /ws
+  apicurio-ui-editing-url: ws://my-apicurio-studio.com/ws
+  #set your Mircocks URL ending with /api
+  #if you do not use Microcks you can leave it empty
+  apicurio-microcks-api-url:  http://my-microcks.com/api
+  #DO NOT CHANGE - change only if you use an already running database
+  apicurio-db-connection-url: jdbc:mysql://apicuriodb:3306/apicuriodb
+  #set the client id of your Keycloak Client used for apicurio
+  apicurio-kc-client-id: apicurio-studio
+  #set the Keycloak Realm
+  apicurio-kc-realm: Apicurio
+  # set your Microcks Client id - it expects the same realm as your Apicurio client
+  apicurio-microcks-client-id: microcks-serviceaccount
+  #enable/disable share-with-everyone feature setting it "true" or "false"
+  apicurio-ui-feature-share-with-everyone: "true"
+  #enable disable Microcks integration setting it "true" or "false"
+  apicurio-ui-feature-microcks: "false"
+```
+
+### apicurio-secrets
+
+Remember that all secrets in k8s are base 64 encoded. Declare the variables in the following manner:
+
+```
+  #a secure password for the database user
+  db-password:
+  #a secure passwort for the database root user
+  db-root-password:
+  #name of the database user
+  db-user:
+  #Keycloak client secret from your Apicurio Client
+  apicurio-kc-client-secret:
+  #Keycloak client secret from your Mickrocks Client
+  apicurio-microcks-client-secret:
+
+```
+
+### Services
+
+Regarding on the Kubernetes Cluster you either use NodePorts or Ingresses. 
+If you use NodePorts change the Services in apicurio-studio-services.yaml to type NodePort.
+If you use Ingresses setup the host path in apicurio-studio-ingresses.yaml.
+It is recommended for a testing environment to use a reverse proxy outside of your kubernetes cluster and  redirect all traffic to Nodeports you specified in apicurio-studio-services.yaml.
+Remember to either change the URLs in apicurio-configmap.yaml or setup your Reverse Proxy. Besides that, remember that Apicurio Studio uses Websockets and thus changes the protocol (http/s to ws/s).
+
+## Deployment
+
+When you finished configuring the apicurio-configmap.yaml and apicurio-secrets.yaml Apicurio-Studio is ready to deploy!
+Depending on the k8s settings, especially regarding the storage provisioner, it may be useful to create PV and PVCs first with the database deploying first.
+
+
+```
+kubectl apply -f mysql-apicurio-persistancevolumeclaim.yaml
+kubectl apply -f apicurio-configmap.yaml
+kubectl apply -f apicurio-secrets.yaml
+kubectl apply -f apicurio-studio-db-deployment.yaml
+#deploying all configs at that moment is save, as kubernetes does not change any configs if they have not been changed between. Secondly, this is your 'i feel lucky' approach if you only want to use one command
+kubectl apply -f .
+```
+
+And you're done! Happy APIing!

--- a/distro/kubernetes/apicurio-configmap.yaml
+++ b/distro/kubernetes/apicurio-configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: apicurio-configmap
+data:
+  keycloak-url:  http://KEYCLOAK_URL/auth
+  apicurio-ui-logout-redirect-uri: /
+  apicurio-ui-hub-api-url: http://APICURIO_URL/studio-api
+  apicurio-ui-editing-url: ws://APICURIO_URL/ws
+  apicurio-microcks-api-url:  http://MICROCKS_URL/api
+  apicurio-db-connection-url: jdbc:mysql://apicuriodb:3306/apicuriodb
+  apicurio-kc-client-id: apicurio-studio
+  apicurio-kc-realm: Apicurio
+  apicurio-microcks-client-id: microcks-serviceaccount
+  apicurio-ui-feature-share-with-everyone: "true"
+  apicurio-ui-feature-microcks: "false"

--- a/distro/kubernetes/apicurio-secrets.yaml
+++ b/distro/kubernetes/apicurio-secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: apicurio-secret
+type: Opaque
+data:
+  db-password:
+  db-root-password: 
+  db-user: 
+  apicurio-kc-client-secret: 
+  apicurio-microcks-client-secret: 

--- a/distro/kubernetes/apicurio-studio-api-deployment.yaml
+++ b/distro/kubernetes/apicurio-studio-api-deployment.yaml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    module: apicurio-studio-api
+  name: apicurio-studio-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      module: apicurio-studio-api
+  template:
+    metadata:
+      labels:
+        module: apicurio-studio-api
+    spec:
+      containers:
+      - env:
+#        - name: APICURIO_LOGGING_LEVEL
+#          value: debug
+        - name: APICURIO_DB_CONNECTION_URL
+          valueFrom:
+            configMapKeyRef:
+              name: apicurio-configmap
+              key: apicurio-db-connection-url     
+        - name: APICURIO_DB_DRIVER_NAME
+          value: mysql
+        - name: APICURIO_DB_INITIALIZE
+          value: "true"
+        - name: APICURIO_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: apicurio-secret
+              key: db-password
+        - name: APICURIO_DB_TYPE
+          value: mysql5
+        - name: APICURIO_DB_USER_NAME
+          valueFrom:
+            secretKeyRef:
+              name: apicurio-secret
+              key: db-user
+        - name: APICURIO_MICROCKS_API_URL
+          valueFrom:
+            configMapKeyRef:
+              name: apicurio-configmap
+              key: apicurio-microcks-api-url
+        - name: APICURIO_MICROCKS_CLIENT_ID
+          valueFrom:
+            configMapKeyRef:
+              name: apicurio-configmap
+              key: apicurio-microcks-client-id
+        - name: APICURIO_MICROCKS_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: apicurio-secret
+              key: apicurio-microcks-client-secret
+        - name: APICURIO_KC_AUTH_URL
+          valueFrom:
+            configMapKeyRef:
+              name: apicurio-configmap
+              key: keycloak-url
+        - name: APICURIO_KC_REALM
+          valueFrom:
+            configMapKeyRef:
+              name: apicurio-configmap
+              key: apicurio-kc-realm          
+        - name: APICURIO_KC_CLIENT_ID
+          valueFrom:
+            configMapKeyRef:
+              name: apicurio-configmap
+              key: apicurio-kc-client-id
+        - name: APICURIO_KC_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: apicurio-secret
+              key: apicurio-kc-client-secret
+        - name: APICURIO_SHARE_FOR_EVERYONE
+          valueFrom:
+            configMapKeyRef:
+              name: apicurio-configmap
+              key: apicurio-ui-feature-share-with-everyone
+        - name: JAVA_TOOL_OPTIONS
+          value: -Djava.net.preferIPv4Stack=true
+        image: 'apicurio/apicurio-studio-api'
+        name: apicurio-studio-api
+        ports:
+        - containerPort: 8080
+      restartPolicy: Always
+      volumes:
+      - name: apicurio-secret
+        secret:
+          secretName: apicurio-secret
+      - name: apicurio-configmap
+        configMap:
+          name: apicurio-cofngimap

--- a/distro/kubernetes/apicurio-studio-db-deployment.yaml
+++ b/distro/kubernetes/apicurio-studio-db-deployment.yaml
@@ -1,0 +1,55 @@
+#change apiversion to extensions/v1beta if kubernetes < v1.16.0
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    module: apicurio-studio-db
+  name: apicurio-studio-db
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      module: apicurio-studio-db
+  template:
+    metadata:
+      labels:
+        module: apicurio-studio-db
+    spec:
+      containers:
+      - args:
+        - --default-authentication-plugin=mysql_native_password
+        - --character-set-server=utf8mb4
+        - --collation-server=utf8mb4_unicode_ci
+        env:
+        - name: MYSQL_DATABASE
+          value: apicuriodb
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef: 
+              name: apicurio-secret
+              key: db-password
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: apicurio-secret
+              key: db-root-password
+        - name: MYSQL_USER
+          valueFrom:
+            secretKeyRef:
+              name: apicurio-secret
+              key: db-user
+        image: percona:5.7
+        name: apicurio-studio-db
+        volumeMounts:
+        - mountPath: /var/lib/mysql
+          name: mysql-apicurio
+      restartPolicy: Always
+      volumes:
+      - name: mysql-apicurio
+        persistentVolumeClaim:
+         claimName: apicuriodata
+      - name: apicurio-secret
+        secret:
+          secretName: apicurio-secret

--- a/distro/kubernetes/apicurio-studio-ingresses.yaml
+++ b/distro/kubernetes/apicurio-studio-ingresses.yaml
@@ -1,0 +1,61 @@
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: apicurio-studio-api
+  annotations:
+#if subpath needed uncomment line and add to path beneath in specs
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+  labels:
+    module: apicurio-studio-api
+spec:
+  rules:
+  - host: localhost
+    http:
+      paths:
+      - backend:
+          serviceName: "apicurio-studio-api"
+          servicePort: 8091
+        path: /studio-api/?(.*)
+---
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: apicurio-studio-ui
+  annotations:
+#    ingress.kubernetes.io/rewrite-target: /
+  labels:
+    module: apicurio-studio-ui
+spec:
+  rules:
+  - host: localhost
+    http:
+      paths:
+      - backend:
+          serviceName: "apicurio-studio-ui"
+          servicePort: 8093
+        path: /
+---
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: apicurio-studio-ui
+  annotations:
+    #    ingress.kubernetes.io/rewrite-target: /
+    ingress.kubernetes.io/proxy-connect-timeout: "3600"
+    ingress.kubernetes.io/proxy-read-timeout: "3600"
+    ingress.kubernetes.io/proxy-send-timeout: "3600"
+    ingress.kubernetes.io/send-timeout: "3600"    
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
+  labels:
+    module: apicurio-studio-ws
+spec:
+  rules:
+  - host: localhost
+    http:
+      paths:
+      - backend:
+          serviceName: "apicurio-studio-ws"
+          servicePort: 8092
+        path: /ws

--- a/distro/kubernetes/apicurio-studio-services.yaml
+++ b/distro/kubernetes/apicurio-studio-services.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    module: apicurio-studio-api
+  name: apicurio-studio-api
+spec:
+  ports:
+  - name: "8091"
+    port: 8091
+    targetPort: 8080
+  selector:
+    module: apicurio-studio-api
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    module: apicurio-studio-ui
+  name: apicurio-studio-ui
+spec:
+  ports:
+  - name: "8093"
+    port: 8093
+    targetPort: 8080
+  selector:
+    module: apicurio-studio-ui
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    module: apicurio-studio-ws
+  name: apicurio-studio-ws
+spec:
+  ports:
+  - name: "8092"
+    port: 8092
+    targetPort: 8080
+    protocol: TCP
+  selector:
+    module: apicurio-studio-ws
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    module: apicurio-studio-db
+  name: apicuriodb
+spec:
+  ports:
+  - name: "3306"
+    port: 3306
+    targetPort: 3306
+  selector:
+    module: apicurio-studio-db
+

--- a/distro/kubernetes/apicurio-studio-ui-deployment.yaml
+++ b/distro/kubernetes/apicurio-studio-ui-deployment.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    module: apicurio-studio-ui
+  name: apicurio-studio-ui
+spec:
+  replicas: 1
+  strategy: {}
+  selector:
+    matchLabels:
+      module: apicurio-studio-ui
+  template:
+    metadata:
+      labels:
+        module: apicurio-studio-ui
+    spec:
+      containers:
+      - env:
+#        - name: APICURIO_LOGGING_LEVEL
+#          value: debug
+        - name: APICURIO_KC_AUTH_URL
+          valueFrom:
+            configMapKeyRef:
+              name: apicurio-configmap
+              key: keycloak-url
+        - name: APICURIO_KC_REALM
+          valueFrom:
+            configMapKeyRef:
+              name: apicurio-configmap
+              key: apicurio-kc-realm          
+        - name: APICURIO_KC_CLIENT_ID
+          valueFrom:
+            configMapKeyRef:
+              name: apicurio-configmap
+              key: apicurio-kc-client-id
+        - name: APICURIO_KC_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: apicurio-secret
+              key: apicurio-kc-client-secret
+        - name: APICURIO_UI_FEATURE_MICROCKS
+          valueFrom:
+            configMapKeyRef:
+              name: apicurio-configmap
+              key: apicurio-ui-feature-microcks          
+        - name: APICURIO_UI_FEATURE_SHARE_WITH_EVERYONE
+          valueFrom:
+            configMapKeyRef:
+              name: apicurio-configmap
+              key: apicurio-ui-feature-share-with-everyone          
+        - name: APICURIO_UI_LOGOUT_REDIRECT_URI
+          valueFrom:
+            configMapKeyRef:
+              name: apicurio-configmap
+              key: apicurio-ui-logout-redirect-uri
+        - name: APICURIO_UI_HUB_API_URL
+          valueFrom:
+            configMapKeyRef:
+              name: apicurio-configmap
+              key: apicurio-ui-hub-api-url
+        - name: APICURIO_UI_EDITING_URL
+          valueFrom:
+            configMapKeyRef:
+              name: apicurio-configmap
+              key: apicurio-ui-editing-url
+        - name: JAVA_TOOL_OPTIONS
+          value: -Djava.net.preferIPv4Stack=true
+        - name: APICURIO_MICROCKS_API_URL
+          valueFrom:
+            configMapKeyRef:
+              name: apicurio-configmap
+              key: apicurio-microcks-api-url
+        - name: APICURIO_MICROCKS_CLIENT_ID
+          valueFrom:
+            configMapKeyRef:
+              name: apicurio-configmap
+              key: apicurio-microcks-client-id
+        - name: APICURIO_MICROCKS_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: apicurio-secret
+              key: apicurio-microcks-client-secret
+        image: 'apicurio/apicurio-studio-ui'
+        imagePullPolicy: Always
+        name: apicurio-studio-ui
+        ports:
+        - containerPort: 8080
+      restartPolicy: Always

--- a/distro/kubernetes/apicurio-studio-ws-deployment.yaml
+++ b/distro/kubernetes/apicurio-studio-ws-deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    module: apicurio-studio-ws
+  name: apicurio-studio-ws
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      module: apicurio-studio-ws
+  template:
+    metadata:
+      labels:
+        module: apicurio-studio-ws
+    spec:
+      containers:
+      - env:
+#        - name: APICURIO_LOGGING_LEVEL
+#          value: debug
+        - name: APICURIO_DB_CONNECTION_URL
+          valueFrom:
+            configMapKeyRef:
+              name: apicurio-configmap
+              key: keycloak-url
+        - name: APICURIO_DB_DRIVER_NAME
+          value: mysql
+        - name: APICURIO_DB_INITIALIZE
+          value: "false"
+        - name: APICURIO_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: apicurio-secret
+              key: db-password
+        - name: APICURIO_DB_TYPE
+          value: mysql5
+        - name: APICURIO_DB_USER_NAME
+          valueFrom:
+            secretKeyRef:
+              name: apicurio-secret
+              key: db-user
+        - name: JAVA_TOOL_OPTIONS
+          value: -Djava.net.preferIPv4Stack=true
+        image: 'apicurio/apicurio-studio-ws'
+        name: apicurio-studio-ws
+        ports:
+        - containerPort: 8080
+      restartPolicy: Always

--- a/distro/kubernetes/mysql-apicurio-persistentvolumeclaim.yaml
+++ b/distro/kubernetes/mysql-apicurio-persistentvolumeclaim.yaml
@@ -5,20 +5,16 @@ metadata:
   labels:
     type: local
 spec:
-  storageClassName: manual
   capacity:
     storage: 5Gi
   accessModes:
     - ReadWriteOnce
-  hostPath:
-    path: "/tmp/db"
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: apicuriodata
 spec:
-  storageClassName: manual
   accessModes:
     - ReadWriteOnce
   resources:

--- a/distro/kubernetes/mysql-apicurio-persistentvolumeclaim.yaml
+++ b/distro/kubernetes/mysql-apicurio-persistentvolumeclaim.yaml
@@ -1,0 +1,26 @@
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: apicuriodb-aws-pv
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/tmp/db"
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: apicuriodata
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4Gi

--- a/distro/kubernetes/mysql-apicurio-persistentvolumeclaim.yaml
+++ b/distro/kubernetes/mysql-apicurio-persistentvolumeclaim.yaml
@@ -1,7 +1,7 @@
 kind: PersistentVolume
 apiVersion: v1
 metadata:
-  name: apicuriodb-aws-pv
+  name: apicuriodb-pv
   labels:
     type: local
 spec:


### PR DESCRIPTION
This Pull Request adds basic kubernetes configs.

It is separated into 
4  Deployment configs (-api -ws -ui -db)
1 configmap
1 secret config
1 example persistentvolumeclaim
1 Service Config
1 Ingress Config
1 Readme

As of now it should not be used in production, as there is no standard way of exposing the proper paths. The user can choose between  editing the services to use NodePorts or edit the Ingresses to suit its needs. Either way it needs to be reviewed to be set productive.