### PR TITLE
Fix invalid default keycloak password in docker-compose readme

### DIFF
--- a/distro/docker-compose/Readme.md
+++ b/distro/docker-compose/Readme.md
@@ -129,7 +129,7 @@ The Keycloak instance is already configured, you don't have to create the realms
 At the first start there are no default users added to Keycloak. Please navigate to:
 `http://YOUR_IP:8090`
 
-The default credentials for Keycloak are: `admin` and `admin_password`
+The default credentials for Keycloak are: `admin` and the password can be found in the previously generated `.env` file, under `KEYCLOAK_PASSWORD`.
 
 Select Apicurio realm and add a user to it. After this, you have to do this with Microcks too.
 


### PR DESCRIPTION
This looks like it is probably outdated. 

The keycloak password is generated in setup.sh [here](https://github.com/Apicurio/apicurio-studio/blob/master/distro/docker-compose/setup.sh#L27) and used in docker-compose [here](https://github.com/Apicurio/apicurio-studio/blob/master/distro/docker-compose/docker-compose.keycloak.yml#L27) - via the .env file [here](https://github.com/Apicurio/apicurio-studio/blob/master/distro/docker-compose/.env.template#L17).