### PR TITLE
Fix Unrecognized exception '$objectToArray errors

### DIFF
--- a/distro/docker-compose/docker-compose.microcks.yml
+++ b/distro/docker-compose/docker-compose.microcks.yml
@@ -7,7 +7,7 @@ networks:
   main:
 services:
   mongo:
-    image: mongo:3.3.12
+    image: mongo:3.4.23
     container_name: microcks-mongo
     volumes:
       - "mongo_data2:/data/db"


### PR DESCRIPTION
this error message shows up in the logs, when running with mongo 3.3: 
```
com.mongodb.MongoCommandException: Command failed with error 168 (InvalidPipelineOperator): 'Unrecognized expression '$objectToArray'' on server mongo:27017. The full response is {"ok": 0.0, "errmsg": "Unrecognized expression '$objectToArray'", "code": 168, "codeName": "InvalidPipelineOperator"}
```
Upgrading to mongo 3.4.23 fixes that. (same version as currently used in [the docker-compose on the microcks repo](https://github.com/microcks/microcks/blob/master/install/docker-compose/microcks.yml#L6) )