### PR TITLE
fixed microcks url starting with https://api

### DIFF
--- a/back-end/hub-api/src/main/java/io/apicurio/hub/api/rest/impl/DesignsResource.java
+++ b/back-end/hub-api/src/main/java/io/apicurio/hub/api/rest/impl/DesignsResource.java
@@ -894,7 +894,7 @@ public class DesignsResource implements IDesignsResource {
             String mockURL = null;
             String microcksURL = config.getMicrocksApiUrl();
             try {
-                mockURL = microcksURL.substring(0, microcksURL.indexOf("/api")) + "/#/services/"
+                mockURL = microcksURL.substring(0, microcksURL.lastIndexOf("/api")) + "/#/services/"
                       + URLEncoder.encode(serviceRef, "UTF-8");
             } catch (Exception e) {
                 logger.error("Failed to produce a valid mockURL", e);


### PR DESCRIPTION
This PR addresses #1250

This ensures that microcks URLs starting with https://api... are not parsed incorrectly