### PR TITLE
added APICURIO_SHARE_FOR_EVERYONE to WS deployment in k8s and helm

### DIFF
--- a/distro/helm/templates/apicurio-studio-ws-deployment.yaml
+++ b/distro/helm/templates/apicurio-studio-ws-deployment.yaml
@@ -38,6 +38,8 @@ spec:
               secretKeyRef:
                 name: apicurio-secret
                 key: db-user
+          - name: APICURIO_SHARE_FOR_EVERYONE
+            value: {{ .Values.uiFeatureShareForEveryone | quote }}
           - name: JAVA_TOOL_OPTIONS
             value: {{ .Values.ws.jvmArgs }}
           image: {{ .Values.ws.image }}

--- a/distro/kubernetes/apicurio-studio-ws-deployment.yaml
+++ b/distro/kubernetes/apicurio-studio-ws-deployment.yaml
@@ -39,6 +39,11 @@ spec:
             secretKeyRef:
               name: apicurio-secret
               key: db-user
+        - name: APICURIO_SHARE_FOR_EVERYONE
+          valueFrom:
+            configMapKeyRef:
+              name: apicurio-configmap
+              key: apicurio-ui-feature-share-with-everyone
         - name: JAVA_TOOL_OPTIONS
           value: -Djava.net.preferIPv4Stack=true
         image: 'apicurio/apicurio-studio-ws'


### PR DESCRIPTION
The kubernetes and helm example deployments in distro have the same issue as #954. 

This PR adds the env var to the helm chart and the kubernetes yamls so the share for everyone feature works.
