### PR TITLE
Fixing roadmap page link

### DIFF
--- a/front-end/studio/src/app/pages/dashboard/dashboard.page.html
+++ b/front-end/studio/src/app/pages/dashboard/dashboard.page.html
@@ -20,9 +20,9 @@
                     </p>
                     <div>
                         <ul>
-                            <li><a href="http://www.apicur.io" target="_blank">Learn more about the Apicurio project</a></li>
-                            <li><a href="http://www.apicur.io/roadmap" target="_blank">View our Roadmap</a></li>
-                            <li><a href="http://www.apicur.io/contact" target="_blank">Question or Ideas?  Contact our development team!</a></li>
+                            <li><a href="https://www.apicur.io" target="_blank">Learn more about the Apicurio project</a></li>
+                            <li><a href="https://www.apicur.io/studio/roadmap" target="_blank">View our Roadmap</a></li>
+                            <li><a href="https://www.apicur.io/contact" target="_blank">Question or Ideas?  Contact our development team!</a></li>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
On the Dashboard, "View our Roadmap" was pointing to http://www.apicur.io/roadmap/ that has moved to /studio/roadmap.
I also changed http to https on the two other links.