### PR TITLE
Dereference when generating documentation to support imported data types through preview documentation action

### DIFF
--- a/front-end/servlet/src/main/java/io/apicurio/studio/fe/servlet/servlets/PreviewServlet.java
+++ b/front-end/servlet/src/main/java/io/apicurio/studio/fe/servlet/servlets/PreviewServlet.java
@@ -70,8 +70,8 @@ public class PreviewServlet extends HttpServlet {
         String rid = req.getParameter("rid");
         
         logger.debug("Rendering document preview for API: {}", apiId);
-        
-        String specURL = "download?type=api&format=json&id=" + apiId;
+
+        String specURL = "download?type=api&format=json&dereference=true&id=" + apiId;
         logger.debug("Spec URL: {}", specURL);
         
         String content;


### PR DESCRIPTION
Hi,

Dereferencing the api seems to fix issue #1113 for me.
Please share your thoughts if this fix is adequate.