### PR TITLE
integration events - initial implementation and http cloudevents

### DIFF
--- a/back-end/hub-api/src/main/java/io/apicurio/hub/api/rest/impl/DesignsResource.java
+++ b/back-end/hub-api/src/main/java/io/apicurio/hub/api/rest/impl/DesignsResource.java
@@ -350,7 +350,7 @@ public class DesignsResource implements IDesignsResource {
             throw new ServerError(e);
         }
 
-        eventsService.triggerEvent(ApicurioEventType.DESIGN_CREATED, design.getId(), design);
+        eventsService.triggerEvent(ApicurioEventType.DESIGN_CREATED, design);
 
         return design;
     }
@@ -395,7 +395,7 @@ public class DesignsResource implements IDesignsResource {
 
             metrics.apiCreate(type);
 
-            eventsService.triggerEvent(ApicurioEventType.DESIGN_CREATED, design.getId(), design);
+            eventsService.triggerEvent(ApicurioEventType.DESIGN_CREATED, design);
 
             return design;
         } catch (StorageException e) {
@@ -559,7 +559,7 @@ public class DesignsResource implements IDesignsResource {
             Map<String, String> data = new HashMap<>();
             data.put("id", designId);
             data.put("deletedBy", user);
-            eventsService.triggerEvent(ApicurioEventType.DESIGN_DELETED, designId, data);
+            eventsService.triggerEvent(ApicurioEventType.DESIGN_DELETED, data);
         } catch (StorageException e) {
             throw new ServerError(e);
         }

--- a/back-end/hub-api/src/main/java/io/apicurio/hub/api/rest/impl/DesignsResource.java
+++ b/back-end/hub-api/src/main/java/io/apicurio/hub/api/rest/impl/DesignsResource.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.zip.ZipInputStream;
 
@@ -115,6 +116,8 @@ import io.apicurio.hub.core.exceptions.AccessDeniedException;
 import io.apicurio.hub.core.exceptions.ApiValidationException;
 import io.apicurio.hub.core.exceptions.NotFoundException;
 import io.apicurio.hub.core.exceptions.ServerError;
+import io.apicurio.hub.core.integrations.ApicurioEventType;
+import io.apicurio.hub.core.integrations.EventsService;
 import io.apicurio.hub.core.storage.IStorage;
 import io.apicurio.hub.core.storage.StorageException;
 import io.apicurio.hub.core.util.FormatUtils;
@@ -163,13 +166,16 @@ public class DesignsResource implements IDesignsResource {
     @Inject
     private BitbucketResourceResolver bitbucketResolver;
 
+    @Inject
+    private EventsService eventsService;
+
     /**
      * @see io.apicurio.hub.api.rest.IDesignsResource#listDesigns()
      */
     @Override
     public Collection<ApiDesign> listDesigns() throws ServerError {
         metrics.apiCall("/designs", "GET");
-        
+
         try {
             logger.debug("Listing API Designs");
             String user = this.security.getCurrentUser().getLogin();
@@ -343,7 +349,9 @@ public class DesignsResource implements IDesignsResource {
         } catch (StorageException e) {
             throw new ServerError(e);
         }
-        
+
+        eventsService.triggerEvent(ApicurioEventType.DESIGN_CREATED, design.getId(), design);
+
         return design;
     }
 
@@ -384,9 +392,11 @@ public class DesignsResource implements IDesignsResource {
             // Create the API Design in the database
             String designId = storage.createApiDesign(user, design, content);
             design.setId(designId);
-            
+
             metrics.apiCreate(type);
-            
+
+            eventsService.triggerEvent(ApicurioEventType.DESIGN_CREATED, design.getId(), design);
+
             return design;
         } catch (StorageException e) {
             throw new ServerError(e);
@@ -542,15 +552,19 @@ public class DesignsResource implements IDesignsResource {
     public void deleteDesign(String designId) throws ServerError, NotFoundException {
         logger.debug("Deleting an API Design with ID {}", designId);
         metrics.apiCall("/designs/{designId}", "DELETE");
-        
+
         try {
             String user = this.security.getCurrentUser().getLogin();
             this.storage.deleteApiDesign(user, designId);
+            Map<String, String> data = new HashMap<>();
+            data.put("id", designId);
+            data.put("deletedBy", user);
+            eventsService.triggerEvent(ApicurioEventType.DESIGN_DELETED, designId, data);
         } catch (StorageException e) {
             throw new ServerError(e);
         }
     }
-    
+
     /**
      * @see io.apicurio.hub.api.rest.IDesignsResource#getContributors(java.lang.String)
      */

--- a/back-end/hub-api/src/test/java/io/apicurio/hub/api/rest/impl/DesignsResourceTest.java
+++ b/back-end/hub-api/src/test/java/io/apicurio/hub/api/rest/impl/DesignsResourceTest.java
@@ -66,6 +66,7 @@ import io.apicurio.hub.core.exceptions.NotFoundException;
 import io.apicurio.hub.core.exceptions.ServerError;
 import io.apicurio.test.core.TestUtil;
 import test.io.apicurio.hub.api.MockEditingSessionManager;
+import test.io.apicurio.hub.api.MockEventsService;
 import test.io.apicurio.hub.api.MockGitHubService;
 import test.io.apicurio.hub.api.MockMetrics;
 import test.io.apicurio.hub.api.MockSecurityContext;
@@ -90,6 +91,7 @@ public class DesignsResourceTest {
     private GitLabResourceResolver gitLabResolver;
     private BitbucketResourceResolver bitbucketResolver;
     private MockMetrics metrics;
+    private MockEventsService eventsService;
 
     @Before
     public void setUp() {
@@ -104,6 +106,7 @@ public class DesignsResourceTest {
         gitHubResolver = new GitHubResourceResolver();
         gitLabResolver = new GitLabResourceResolver();
         bitbucketResolver = new BitbucketResourceResolver();
+        eventsService = new MockEventsService();
 
         sourceConnectorFactory = new SourceConnectorFactory();
         github = new MockGitHubService();
@@ -128,8 +131,9 @@ public class DesignsResourceTest {
         TestUtil.setPrivateField(resource, "gitHubResolver", gitHubResolver);
         TestUtil.setPrivateField(resource, "gitLabResolver", gitLabResolver);
         TestUtil.setPrivateField(resource, "bitbucketResolver", bitbucketResolver);
+        TestUtil.setPrivateField(resource, "eventsService", eventsService);
     }
-    
+
     @After
     public void tearDown() throws Exception {
     }

--- a/back-end/hub-api/src/test/java/test/io/apicurio/hub/api/MockEventsService.java
+++ b/back-end/hub-api/src/test/java/test/io/apicurio/hub/api/MockEventsService.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package test.io.apicurio.hub.api;
+
+import io.apicurio.hub.core.integrations.ApicurioEventType;
+import io.apicurio.hub.core.integrations.EventsService;
+
+/**
+ * @author Fabian Martinez
+ */
+public class MockEventsService implements EventsService {
+
+    @Override
+    public boolean isConfigured() {
+        return false;
+    }
+
+    @Override
+    public void triggerEvent(ApicurioEventType type, String designId, Object data) {
+
+    }
+
+}

--- a/back-end/hub-api/src/test/java/test/io/apicurio/hub/api/MockEventsService.java
+++ b/back-end/hub-api/src/test/java/test/io/apicurio/hub/api/MockEventsService.java
@@ -29,7 +29,7 @@ public class MockEventsService implements EventsService {
     }
 
     @Override
-    public void triggerEvent(ApicurioEventType type, String designId, Object data) {
+    public void triggerEvent(ApicurioEventType type, Object data) {
 
     }
 

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/config/HubConfiguration.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/config/HubConfiguration.java
@@ -103,6 +103,9 @@ public class HubConfiguration extends Configuration {
     private static final String INFINISPAN_TRANSPORT_ENV = "APICURIO_HUB_EDITING_SESSION_TRANSPORT_";
     private static final String INFINISPAN_TRANSPORT_SYSPROP = "apicurio.hub.editing.session.transport.";
 
+    private static final String WEBHOOKS_CONFIG_ENV = "APICURIO_HUB_INTEGRATIONS_HTTP_";
+    private static final String WEBHOOKS_CONFIG_SYSPROP = "apicurio.hub.integrations.http.";
+
     /**
      * @return the configured JDBC type (default: h2)
      */
@@ -286,5 +289,12 @@ public class HubConfiguration extends Configuration {
      */
     public Properties getInfinispanTransportProperties() {
         return getConfigurationProperties(INFINISPAN_TRANSPORT_ENV, INFINISPAN_TRANSPORT_SYSPROP, false);
+    }
+
+    /**
+     * @return Http integration events, a.k.a webhooks, configuration properties
+     */
+    public Properties getWebhooksConfiguration() {
+        return getConfigurationProperties(WEBHOOKS_CONFIG_ENV, WEBHOOKS_CONFIG_SYSPROP, false);
     }
 }

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/integrations/ApicurioEventType.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/integrations/ApicurioEventType.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.hub.core.integrations;
+
+/**
+ * @author Fabian Martinez
+ */
+public enum ApicurioEventType {
+
+    DESIGN_CREATED,
+    DESIGN_UPDATED,
+    DESIGN_DELETED;
+
+    private String cloudEventType;
+
+    private ApicurioEventType() {
+        this.cloudEventType = "io.apicurio.hub."+this.name().toLowerCase().replace("_", "-");
+    }
+
+    public String cloudEventType() {
+        return this.cloudEventType;
+    }
+
+}

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/integrations/ApicurioEventType.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/integrations/ApicurioEventType.java
@@ -20,14 +20,14 @@ package io.apicurio.hub.core.integrations;
  */
 public enum ApicurioEventType {
 
-    DESIGN_CREATED,
-    DESIGN_UPDATED,
-    DESIGN_DELETED;
+    DESIGN_CREATED("io.apicurio.hub.design-created"),
+    DESIGN_UPDATED("io.apicurio.hub.design-updated"),
+    DESIGN_DELETED("io.apicurio.hub.design-deleted");
 
     private String cloudEventType;
 
-    private ApicurioEventType() {
-        this.cloudEventType = "io.apicurio.hub."+this.name().toLowerCase().replace("_", "-");
+    private ApicurioEventType(String cloudEventType) {
+        this.cloudEventType = cloudEventType;
     }
 
     public String cloudEventType() {

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/integrations/EventSink.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/integrations/EventSink.java
@@ -9,7 +9,7 @@ public interface EventSink {
 
     boolean isConfigured();
 
-    void handle(ApicurioEventType type, String designId, byte[] data);
+    void handle(ApicurioEventType type, byte[] data);
 
 }
 

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/integrations/EventSink.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/integrations/EventSink.java
@@ -1,0 +1,15 @@
+package io.apicurio.hub.core.integrations;
+
+/**
+ * @author Fabian Martinez
+ */
+public interface EventSink {
+
+    String name();
+
+    boolean isConfigured();
+
+    void handle(ApicurioEventType type, String designId, byte[] data);
+
+}
+

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/integrations/EventsService.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/integrations/EventsService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.hub.core.integrations;
+
+/**
+ * @author Fabian Martinez
+ */
+public interface EventsService {
+
+    boolean isConfigured();
+
+    void triggerEvent(ApicurioEventType type, String designId, Object data);
+
+}

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/integrations/EventsService.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/integrations/EventsService.java
@@ -22,6 +22,6 @@ public interface EventsService {
 
     boolean isConfigured();
 
-    void triggerEvent(ApicurioEventType type, String designId, Object data);
+    void triggerEvent(ApicurioEventType type, Object data);
 
 }

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/integrations/EventsServiceImpl.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/integrations/EventsServiceImpl.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.hub.core.integrations;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author Fabian Martinez
+ */
+@ApplicationScoped
+public class EventsServiceImpl implements EventsService {
+
+    private static final Logger log = LoggerFactory.getLogger(EventsServiceImpl.class);
+
+    private ObjectMapper mapper;
+    private boolean configuredSinks = false;
+    private List<EventSink> subscriptions;
+    private ExecutorService executor;
+
+    @Inject
+    Instance<EventSink> sinks;
+
+    @PostConstruct
+    public void init() {
+        for (EventSink sink : sinks) {
+            if (sink.isConfigured()) {
+                configuredSinks = true;
+                if (subscriptions == null) {
+                    subscriptions = new ArrayList<>();
+                }
+                log.info("Subscribing sink " + sink.name());
+                subscriptions.add(sink);
+            }
+        }
+        if (configuredSinks) {
+            executor = new ThreadPoolExecutor(1, 3, 5, TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>());
+        }
+    }
+
+    @Override
+    public boolean isConfigured() {
+        return configuredSinks;
+    }
+
+    @Override
+    public void triggerEvent(ApicurioEventType type, String designId, Object data) {
+        if (configuredSinks && data != null) {
+            byte[] buffer;
+            try {
+                buffer = getMapper().writeValueAsBytes(data);
+            } catch (JsonProcessingException e) {
+                log.error("Error serializing event data", e);
+                return;
+            }
+            executor.submit(() -> {
+               for (EventSink sink : subscriptions) {
+                   try {
+                       sink.handle(type, designId, buffer);
+                   } catch (Exception e) {
+                       log.error("Error sending event in sink " + sink.name(), e);
+                   }
+               }
+            });
+        }
+    }
+
+    private synchronized ObjectMapper getMapper() {
+        if (mapper == null) {
+            mapper = new ObjectMapper();
+            mapper.setSerializationInclusion(Include.NON_NULL);
+        }
+        return mapper;
+    }
+
+}

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/integrations/http/HttpEventSink.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/integrations/http/HttpEventSink.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.hub.core.integrations.http;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ByteArrayEntity;
+import org.apache.http.entity.ContentType;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.apicurio.hub.core.integrations.ApicurioEventType;
+import io.apicurio.hub.core.integrations.EventSink;
+
+@ApplicationScoped
+public class HttpEventSink implements EventSink {
+
+    private static final Logger log = LoggerFactory.getLogger(HttpEventSink.class);
+
+    private HttpClient httpClient;
+
+    @Inject
+    HttpSinksConfiguration configuration;
+
+    @Override
+    public String name() {
+        return "http sink";
+    }
+
+    @Override
+    public boolean isConfigured() {
+        return configuration.isConfigured();
+    }
+
+    @Override
+    public void handle(ApicurioEventType type, String designId, byte[] data) {
+
+        log.info("Firing event " + type);
+
+        for (HttpSinkConfiguration httpSink : configuration.httpSinks()) {
+            sendEventHttp(type, httpSink, data);
+        }
+
+    }
+
+    private void sendEventHttp(ApicurioEventType type, HttpSinkConfiguration httpSink, byte[] data) {
+        try {
+            log.debug("Sending event to sink "+httpSink.getName());
+
+            HttpPost request = new HttpPost(httpSink.getEndpoint());
+            request.addHeader("ce-id", UUID.randomUUID().toString());
+            request.addHeader("ce-specversion", "1.0");
+            request.addHeader("ce-source", "apicurio-registry");
+            request.addHeader("ce-type", type.cloudEventType());
+            request.addHeader("content-type", ContentType.APPLICATION_JSON.getMimeType());
+            request.setEntity(new ByteArrayEntity(data, ContentType.APPLICATION_JSON));
+            try {
+                HttpResponse response = getHttpClient().execute(request);
+                if (response.getStatusLine().getStatusCode() < 200 || response.getStatusLine().getStatusCode() > 299) {
+                    log.warn("Http sink {} return status code {}", httpSink.getName(), response.getStatusLine().getStatusCode());
+                }
+            } catch (IOException e) {
+                log.error("Error sending event to " + httpSink.getEndpoint(), e);
+            }
+
+        } catch (Exception e) {
+            log.error("Error sending http event", e);
+        }
+    }
+
+    private synchronized HttpClient getHttpClient() {
+
+        if (httpClient == null) {
+            httpClient = HttpClientBuilder.create().build();
+        }
+        return httpClient;
+    }
+
+}

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/integrations/http/HttpEventSinkConfiguration.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/integrations/http/HttpEventSinkConfiguration.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.hub.core.integrations.http;
+
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+import io.apicurio.hub.core.config.HubConfiguration;
+
+/**
+ * @author Fabian Martinez
+ */
+@ApplicationScoped
+public class HttpEventSinkConfiguration {
+
+    @Produces
+    public HttpSinksConfiguration sinkConfig(HubConfiguration configuration) {
+        Properties properties = configuration.getWebhooksConfiguration();
+        List<HttpSinkConfiguration> httpSinks = properties.stringPropertyNames().stream()
+            .map(key -> new HttpSinkConfiguration(key, properties.getProperty(key)))
+            .collect(Collectors.toList());
+        return new HttpSinksConfiguration(httpSinks);
+    }
+
+
+}

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/integrations/http/HttpSinkConfiguration.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/integrations/http/HttpSinkConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.hub.core.integrations.http;
+
+/**
+ * @author Fabian Martinez
+ */
+public class HttpSinkConfiguration {
+    
+    private String name;
+    private String endpoint;
+
+    public HttpSinkConfiguration(String name, String endpoint) {
+        this.name = name;
+        this.endpoint = endpoint;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+}

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/integrations/http/HttpSinksConfiguration.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/integrations/http/HttpSinksConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.apicurio.hub.core.integrations.http;
+
+import java.util.List;
+
+/**
+ * @author Fabian Martinez
+ */
+public class HttpSinksConfiguration {
+
+    private List<HttpSinkConfiguration> httpSinks;
+
+    public HttpSinksConfiguration(List<HttpSinkConfiguration> httpSinks) {
+        this.httpSinks = httpSinks;
+    }
+
+    public List<HttpSinkConfiguration> httpSinks() {
+        return this.httpSinks;
+    }
+
+    public boolean isConfigured() {
+        return this.httpSinks != null && !this.httpSinks.isEmpty();
+    }
+
+}

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/storage/RollupExecutor.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/storage/RollupExecutor.java
@@ -95,7 +95,7 @@ public class RollupExecutor implements IRollupExecutor {
                     storage.updateApiDesign(userId, design);
                 }
             } finally {
-                eventsService.triggerEvent(ApicurioEventType.DESIGN_UPDATED, designId, design);
+                eventsService.triggerEvent(ApicurioEventType.DESIGN_UPDATED, design);
             }
         } catch (Exception e) {
             // Not the end of the world if we fail to update the API's meta-data

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/storage/RollupExecutor.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/storage/RollupExecutor.java
@@ -23,6 +23,8 @@ import io.apicurio.hub.core.beans.ApiDesignResourceInfo;
 import io.apicurio.hub.core.cmd.OaiCommandException;
 import io.apicurio.hub.core.cmd.OaiCommandExecutor;
 import io.apicurio.hub.core.exceptions.NotFoundException;
+import io.apicurio.hub.core.integrations.ApicurioEventType;
+import io.apicurio.hub.core.integrations.EventsService;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,6 +48,8 @@ public class RollupExecutor implements IRollupExecutor {
     private IStorage storage;
     @Inject
     private OaiCommandExecutor oaiCommandExecutor;
+    @Inject
+    private EventsService eventsService;
 
     /**
      * @see io.apicurio.hub.core.storage.IRollupExecutor#rollupCommands(java.lang.String, java.lang.String)
@@ -85,9 +89,13 @@ public class RollupExecutor implements IRollupExecutor {
                 design.setTags(info.getTags());
                 dirty = true;
             }
-            if (dirty) {
-                logger.debug("API design {} meta-data changed, updating in storage.", designId);
-                storage.updateApiDesign(userId, design);
+            try {
+                if (dirty) {
+                    logger.debug("API design {} meta-data changed, updating in storage.", designId);
+                    storage.updateApiDesign(userId, design);
+                }
+            } finally {
+                eventsService.triggerEvent(ApicurioEventType.DESIGN_UPDATED, designId, design);
             }
         } catch (Exception e) {
             // Not the end of the world if we fail to update the API's meta-data


### PR DESCRIPTION
Initial implementation of integration events to allow third party apps to easily integrate with apicurio-studio. This provides some interfaces in order to be able to implement different protocols for sending the events. For now only http cloudevents is implemented.

Given the kind of application apicurio-studio is, being able to configure the "firing" of this integrations events in the UI would make a lot of sense. However, because of simplicity, for now configuration is only implemented with env vars and system properties.

So, things remaining for future contributions are:
* configuration in the UI / persistence of the configurations in the DB
* more event protocols, such as kafka
* more event types, at first only design created, updated and deleted are available
* improvements in existing event protocol implementations, such as rate limiting, authentication, retries,...
