### PR TITLE
Enabling Mock with Microcks action for AsyncAPI document too

### DIFF
--- a/front-end/studio/src/app/pages/apis/{apiId}/api-detail.page.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/api-detail.page.ts
@@ -289,7 +289,7 @@ export class ApiDetailPageComponent extends AbstractPageComponent {
             return this.isGraphQL();
         }
         if (action == "mock") {
-            return this.config.isMicrocksEnabled() && this.isOpenApi30();
+            return this.config.isMicrocksEnabled() && (this.isOpenApi30() || this.isAsyncApi20());
         }
         if (action == "edit-data-model") {
             return this.isOpenApi30() || this.isOpenApi20() || this.isAsyncApi20();

--- a/front-end/studio/src/app/pages/apis/{apiId}/mock/mock.page.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/mock/mock.page.html
@@ -33,8 +33,8 @@
                 <span class="pficon pficon-info"></span>
                 <strong>What is this page?</strong>
                 <p style="line-height: 18px">
-                    Use this page to create or update mocks from your API. If the API is using OpenAPI 3.0 format and you have a Microcks 
-                    instance configured, you may choose to publish once or create an importing job.
+                    Use this page to create or update mocks from your API. If the API is using OpenAPI 3.0 or AsyncAPI 2.0 format and you have 
+                    a Microcks instance configured, you may choose to publish once or create an importing job.
                 </p>
             </div>
         </div>


### PR DESCRIPTION
Now that support of AsyncAPI in Microcks is GA and we starting having a descent editor in Studio, we may enable mocking button for AsyncAPI 2.0 document too.