### PR TITLE
Adding template.openshift.io/v1 to apiVersion fixes #1364

### DIFF
--- a/distro/openshift/apicurio-auth-template.yml
+++ b/distro/openshift/apicurio-auth-template.yml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: apicurio-auth

--- a/distro/openshift/apicurio-postgres-template.yml
+++ b/distro/openshift/apicurio-postgres-template.yml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: apicurio-postgres

--- a/distro/openshift/apicurio-standalone-template.yml
+++ b/distro/openshift/apicurio-standalone-template.yml
@@ -1,4 +1,5 @@
-apiVersion: v1
+---
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: apicurio-studio-standalone

--- a/distro/openshift/apicurio-template.yml
+++ b/distro/openshift/apicurio-template.yml
@@ -1,4 +1,5 @@
-apiVersion: v1
+---
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: apicurio-studio


### PR DESCRIPTION
This PR adds the correct version to the OpenShift templates to work properly, tested this with Openshift 4.6.1 running on AWS.

If any more info is needed, please let me know.

