### PR TITLE
Fix member access on undefined (ImportedComponent.from is optional)

### DIFF
--- a/front-end/studio/src/app/pages/apis/{apiId}/_components/import-components.wizard.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/_components/import-components.wizard.html
@@ -62,8 +62,10 @@
                             </p>
                             <ul class="review">
                                 <li *ngFor="let ic of componentsForReview()">
-                                    <span class="from">{{ ic.from.name }}</span>
-                                    <span> / </span>
+                                    <span *ngIf="ic.from">
+                                        <span class="from">{{ ic.from.name }}</span>
+                                        <span> / </span>
+                                    </span>
                                     <span class="component">{{ ic.name }}</span>
                                 </li>
                             </ul>

--- a/front-end/studio/src/app/pages/apis/{apiId}/_components/import-components.wizard.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/_components/import-components.wizard.ts
@@ -321,7 +321,7 @@ export class ImportComponentsWizard {
                     value: component,
                     cells: [
                         { displayName: component.name },
-                        { displayName: component.from.name }
+                        { displayName: component.from ? component.from.name : "No parent resource" }
                     ]
                 };
             });


### PR DESCRIPTION
Hello, 

I'm currently looking into ways to use an external component source (namely an apicurio-registry instance) in the studio import wizard and I've come across this inconsistency: the ImportedComponent.from field is optional and the review panel tries to read its name anyway, causing the wizard component to get stuck on the error report.

This PR wraps the "{ic.from} /" part into a conditional block to prevent this.

---
On a side note, I just found this issue and this is what I'm trying to add to a corporate POC
https://github.com/Apicurio/apicurio-registry/issues/752#issuecomment-688859362