### PR TITLE
Add apicurio-registry as a possible external component source

### DIFF
--- a/back-end/hub-api/pom.xml
+++ b/back-end/hub-api/pom.xml
@@ -40,6 +40,12 @@
             <artifactId>apicurio-data-models</artifactId>
         </dependency>
 
+        <!-- Apicurio Registry Types -->
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-common</artifactId>
+        </dependency>
+
         <!-- Third Party Libraries -->
         <dependency>
             <groupId>org.eclipse.mylyn.github</groupId>

--- a/back-end/hub-api/src/main/java/io/apicurio/hub/api/content/ContentDereferencer.java
+++ b/back-end/hub-api/src/main/java/io/apicurio/hub/api/content/ContentDereferencer.java
@@ -40,11 +40,14 @@ public class ContentDereferencer {
     private AbsoluteReferenceResolver absoluteResolver;
     @Inject
     private InternalReferenceResolver apicurioResolver;
+    @Inject
+    private RegistryReferenceResolver registryResolver;
 
     @PostConstruct
     void init() {
         Library.addReferenceResolver(apicurioResolver);
         Library.addReferenceResolver(absoluteResolver);
+        Library.addReferenceResolver(registryResolver);
     }
     
     /**

--- a/back-end/hub-api/src/main/java/io/apicurio/hub/api/content/RegistryReferenceResolver.java
+++ b/back-end/hub-api/src/main/java/io/apicurio/hub/api/content/RegistryReferenceResolver.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.hub.api.content;
+
+import io.apicurio.hub.core.registry.IRegistry;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.io.IOException;
+import java.net.URI;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Resolves references that are local/internal to Apicurio.  These references will be of the following form:
+ *
+ *   apicurio-registry:ARTIFACT_ID/VERSION#/path/to/Entity
+ *
+ * An example of a valid local reference might be:
+ *
+ *   apicurio-registry:MyRefClient/1#/components/schemas/FooType
+ *
+ * @author c.desc2@gmail.com
+ */
+@ApplicationScoped
+public class RegistryReferenceResolver extends AbstractReferenceResolver {
+
+    private static final Pattern REGISTRY_REFERENCE_PATTERN = Pattern.compile("^(?<artifactId>.+)/(?<artifactVersion>\\d+)$");
+
+    @Inject
+    private IRegistry registry;
+
+    /**
+     * Constructor.
+     */
+    public RegistryReferenceResolver() {
+    }
+
+    /**
+     * @see AbstractReferenceResolver#accepts(URI)
+     */
+    @Override
+    protected boolean accepts(URI uri) {
+        String scheme = uri.getScheme();
+        return scheme != null && scheme.equalsIgnoreCase("apicurio-registry");
+    }
+
+    /**
+     * @see AbstractReferenceResolver#fetchUriContent(URI)
+     */
+    @Override
+    protected String fetchUriContent(URI referenceUri) throws IOException {
+        final String registryReference = referenceUri.getSchemeSpecificPart();
+        final Matcher registryReferenceMatcher = REGISTRY_REFERENCE_PATTERN.matcher(registryReference);
+        if (registryReferenceMatcher.matches()) {
+            final String artifactId = registryReferenceMatcher.group("artifactId");
+            final Integer artifactVersion = Integer.parseInt(registryReferenceMatcher.group("artifactVersion"));
+            return registry.getArtifact(artifactId, artifactVersion);
+        }
+        return null;
+    }
+
+}

--- a/back-end/hub-api/src/main/java/io/apicurio/hub/api/rest/IRegistryResource.java
+++ b/back-end/hub-api/src/main/java/io/apicurio/hub/api/rest/IRegistryResource.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.hub.api.rest;
+
+import io.apicurio.hub.core.exceptions.NotFoundException;
+import io.apicurio.hub.core.exceptions.ServerError;
+import io.apicurio.registry.rest.beans.ArtifactMetaData;
+import io.apicurio.registry.rest.beans.SearchedArtifact;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.Collection;
+
+/**
+ * The interface that defines how to interact with an Apicurio Registry instance.
+ * 
+ * @author c.desc2@gmail.com
+ */
+@Path("registry")
+public interface IRegistryResource {
+    
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Collection<SearchedArtifact> listArtifacts() throws ServerError;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("{artifactId}")
+    public ArtifactMetaData getArtifact(@PathParam("artifactId") String artifactId) throws ServerError, NotFoundException;
+
+    @GET
+    @Produces({ MediaType.APPLICATION_JSON, "application/x-yaml", "application/graphql" })
+    @Path("{artifactId}/{artifactVersion}/content")
+    public Response getContent(@PathParam("artifactId") String artifactId, @PathParam("artifactVersion") Integer artifactVersion,
+                               @QueryParam("dereference") String dereference) throws ServerError, NotFoundException;
+
+}

--- a/back-end/hub-api/src/main/java/io/apicurio/hub/api/rest/impl/RegistryResource.java
+++ b/back-end/hub-api/src/main/java/io/apicurio/hub/api/rest/impl/RegistryResource.java
@@ -30,23 +30,15 @@ public class RegistryResource implements IRegistryResource {
     private IRegistry registry;
 
     @Override
-    public Collection<SearchedArtifact> listArtifacts() throws ServerError {
+    public Collection<SearchedArtifact> listArtifacts() {
         metrics.apiCall("/registry", "GET");
-        try {
-            return registry.listArtifacts();
-        } catch (IOException e) {
-            throw new ServerError(e);
-        }
+        return registry.listArtifacts();
     }
 
     @Override
-    public ArtifactMetaData getArtifact(String artifactId) throws ServerError, NotFoundException {
+    public ArtifactMetaData getArtifact(String artifactId) {
         metrics.apiCall("/registry/{artifactId}", "GET");
-        try {
-            return registry.getArtifactMetaData(artifactId);
-        } catch (IOException e) {
-            throw new ServerError(e);
-        }
+        return registry.getArtifactMetaData(artifactId);
     }
 
     @Override

--- a/back-end/hub-api/src/main/java/io/apicurio/hub/api/rest/impl/RegistryResource.java
+++ b/back-end/hub-api/src/main/java/io/apicurio/hub/api/rest/impl/RegistryResource.java
@@ -1,0 +1,70 @@
+package io.apicurio.hub.api.rest.impl;
+
+import io.apicurio.hub.api.content.ContentDereferencer;
+import io.apicurio.hub.api.metrics.IApiMetrics;
+import io.apicurio.hub.api.rest.IRegistryResource;
+import io.apicurio.hub.core.exceptions.NotFoundException;
+import io.apicurio.hub.core.exceptions.ServerError;
+import io.apicurio.hub.core.registry.IRegistry;
+import io.apicurio.registry.rest.beans.ArtifactMetaData;
+import io.apicurio.registry.rest.beans.SearchedArtifact;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+
+/**
+ * @author c.desc2@gmail.com
+ */
+@ApplicationScoped
+public class RegistryResource implements IRegistryResource {
+
+    @Inject
+    private ContentDereferencer dereferencer;
+    @Inject
+    private IApiMetrics metrics;
+    @Inject
+    private IRegistry registry;
+
+    @Override
+    public Collection<SearchedArtifact> listArtifacts() throws ServerError {
+        metrics.apiCall("/registry", "GET");
+        try {
+            return registry.listArtifacts();
+        } catch (IOException e) {
+            throw new ServerError(e);
+        }
+    }
+
+    @Override
+    public ArtifactMetaData getArtifact(String artifactId) throws ServerError, NotFoundException {
+        metrics.apiCall("/registry/{artifactId}", "GET");
+        try {
+            return registry.getArtifactMetaData(artifactId);
+        } catch (IOException e) {
+            throw new ServerError(e);
+        }
+    }
+
+    @Override
+    public Response getContent(String artifactId, Integer artifactVersion, String dereference) throws ServerError, NotFoundException {
+        metrics.apiCall("/registry/{artifactId}/{artifactVersion}/content", "GET");
+        try {
+            String content = registry.getArtifact(artifactId, artifactVersion);
+            if ("true".equalsIgnoreCase(dereference)) {
+                content = dereferencer.dereference(content);
+            }
+            byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+            String cl = String.valueOf(bytes.length);
+            Response.ResponseBuilder builder = Response.ok().entity(content)
+                    .header("Content-Type", "application/json; charset=" + StandardCharsets.UTF_8)
+                    .header("Content-Length", cl);
+            return builder.build();
+        } catch (IOException e) {
+            throw new ServerError(e);
+        }
+    }
+}

--- a/back-end/hub-core/pom.xml
+++ b/back-end/hub-core/pom.xml
@@ -1,5 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
->
+<project xmlns="http://maven.apache.org/POM/4.0.0">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.apicurio</groupId>
@@ -27,6 +26,13 @@
         <dependency>
             <groupId>io.apicurio</groupId>
             <artifactId>apicurio-data-models</artifactId>
+        </dependency>
+
+        <!-- Apicurio Registry Rest Client -->
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-rest-client</artifactId>
+            <version>1.3.2.Final</version>
         </dependency>
 
         <!-- Kafka (from Registry) -->

--- a/back-end/hub-core/pom.xml
+++ b/back-end/hub-core/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+>
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.apicurio</groupId>

--- a/back-end/hub-core/pom.xml
+++ b/back-end/hub-core/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>io.apicurio</groupId>
             <artifactId>apicurio-registry-rest-client</artifactId>
-            <version>1.3.2.Final</version>
+            <version>${version.apicurio-registry}</version>
         </dependency>
 
         <!-- Kafka (from Registry) -->

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/config/HubConfiguration.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/config/HubConfiguration.java
@@ -106,6 +106,9 @@ public class HubConfiguration extends Configuration {
     private static final String WEBHOOKS_CONFIG_ENV = "APICURIO_HUB_INTEGRATIONS_HTTP_";
     private static final String WEBHOOKS_CONFIG_SYSPROP = "apicurio.hub.integrations.http.";
 
+    private static final String REGISTRY_API_URL_ENV = "APICURIO_REGISTRY_API_URL";
+    private static final String REGISTRY_API_URL_SYSPROP = "apicurio.registry.api.url";
+
     /**
      * @return the configured JDBC type (default: h2)
      */
@@ -296,5 +299,12 @@ public class HubConfiguration extends Configuration {
      */
     public Properties getWebhooksConfiguration() {
         return getConfigurationProperties(WEBHOOKS_CONFIG_ENV, WEBHOOKS_CONFIG_SYSPROP, false);
+    }
+
+    /**
+     * @return the URL of the Apicurio Registry Instance's API.
+     */
+    public String getRegistryApiUrl() {
+        return getConfigurationProperty(REGISTRY_API_URL_ENV, REGISTRY_API_URL_SYSPROP, null);
     }
 }

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/registry/IRegistry.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/registry/IRegistry.java
@@ -6,10 +6,30 @@ import io.apicurio.registry.rest.beans.SearchedArtifact;
 import java.io.IOException;
 import java.util.Collection;
 
+/**
+ * @author c.desc2@gmail.com
+ */
 public interface IRegistry {
-    Collection<SearchedArtifact> listArtifacts() throws IOException;
 
+    /**
+     * Gets all the artifacts the configured registry instance can serve
+     * @return a {@link Collection} of all the {@link SearchedArtifact} objects
+     */
+    Collection<SearchedArtifact> listArtifacts();
+
+    /**
+     * Gets the string resource represented in the configured registry by the given artifactId and artifactVersion
+     * @param artifactId the artifactId
+     * @param artifactVersion the artifactVersion
+     * @return the artifact content
+     * @throws IOException if the content could not be read as UTF_8
+     */
     String getArtifact(String artifactId, Integer artifactVersion) throws IOException;
 
-    ArtifactMetaData getArtifactMetaData(String artifactId) throws IOException;
+    /**
+     * Gets the {@link ArtifactMetaData} for the given artifactId
+     * @param artifactId the artifactId
+     * @return the {@link ArtifactMetaData}
+     */
+    ArtifactMetaData getArtifactMetaData(String artifactId);
 }

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/registry/IRegistry.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/registry/IRegistry.java
@@ -7,6 +7,8 @@ import java.io.IOException;
 import java.util.Collection;
 
 /**
+ * This interface defines the possible actions the Apicurio Studio can perform on a configured Apicurio Registry
+ * As of now, the Studio only gets artifacts and their related metadata / content
  * @author c.desc2@gmail.com
  */
 public interface IRegistry {

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/registry/IRegistry.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/registry/IRegistry.java
@@ -1,0 +1,15 @@
+package io.apicurio.hub.core.registry;
+
+import io.apicurio.registry.rest.beans.ArtifactMetaData;
+import io.apicurio.registry.rest.beans.SearchedArtifact;
+
+import java.io.IOException;
+import java.util.Collection;
+
+public interface IRegistry {
+    Collection<SearchedArtifact> listArtifacts() throws IOException;
+
+    String getArtifact(String artifactId, Integer artifactVersion) throws IOException;
+
+    ArtifactMetaData getArtifactMetaData(String artifactId) throws IOException;
+}

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/registry/http/HttpRegistry.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/registry/http/HttpRegistry.java
@@ -28,7 +28,7 @@ public class HttpRegistry implements IRegistry {
 
     @Inject
     public HttpRegistry(HubConfiguration config) {
-        this.registryRestClient = Optional.ofNullable(config.getRegistryUrl())
+        this.registryRestClient = Optional.ofNullable(config.getRegistryApiUrl())
                 .map(RegistryRestClientFactory::create)
                 .orElse(null);
     }

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/registry/http/HttpRegistry.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/registry/http/HttpRegistry.java
@@ -1,0 +1,99 @@
+package io.apicurio.hub.core.registry.http;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.apicurio.hub.core.config.HubConfiguration;
+import io.apicurio.hub.core.registry.IRegistry;
+import io.apicurio.registry.rest.beans.ArtifactMetaData;
+import io.apicurio.registry.rest.beans.ArtifactSearchResults;
+import io.apicurio.registry.rest.beans.SearchedArtifact;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.entity.ContentType;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Default;
+import javax.inject.Inject;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+@ApplicationScoped
+@Default
+public class HttpRegistry implements IRegistry {
+
+    private static final Logger logger = LoggerFactory.getLogger(HttpRegistry.class);
+    private static CloseableHttpClient httpClient = HttpClients.createDefault();
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @Inject
+    private HubConfiguration config;
+    
+    @Override
+    public Collection<SearchedArtifact> listArtifacts() throws IOException {
+        List<SearchedArtifact> artifactMetaDataList = Collections.emptyList();
+        if (config.getRegistryUrl() != null) {
+            HttpGet get = new HttpGet(String.format("%s/api/search/artifacts", config.getRegistryUrl()));
+            try (CloseableHttpResponse response = httpClient.execute(get)) {
+                if (response.getStatusLine().getStatusCode() >= 200 && response.getStatusLine().getStatusCode() < 300) {
+                    try (InputStream contentStream = response.getEntity().getContent()) {
+                        final ArtifactSearchResults artifactSearchResults = mapper.readValue(contentStream, ArtifactSearchResults.class);
+                        artifactMetaDataList = artifactSearchResults.getArtifacts();
+                    }
+                }
+            }
+        }
+        return artifactMetaDataList;
+    }
+
+    @Override
+    public String getArtifact(String artifactId, Integer artifactVersion) throws IOException {
+        String content = "";
+        if (config.getRegistryUrl() != null) {
+            StringBuilder urlBuilder = new StringBuilder();
+            urlBuilder.append(config.getRegistryUrl())
+                    .append("/api/artifacts/").append(artifactId);
+            if (artifactVersion != null) {
+                urlBuilder.append("/versions/").append(artifactVersion);
+            }
+            HttpGet get = new HttpGet(urlBuilder.toString());
+            try (CloseableHttpResponse response = httpClient.execute(get)) {
+                if (response.getStatusLine().getStatusCode() >= 200 && response.getStatusLine().getStatusCode() < 300) {
+                    try (InputStream contentStream = response.getEntity().getContent()) {
+                        ContentType ct = ContentType.getOrDefault(response.getEntity());
+                        String encoding = StandardCharsets.UTF_8.name();
+                        if (ct != null && ct.getCharset() != null) {
+                            encoding = ct.getCharset().name();
+                        }
+                        content = IOUtils.toString(contentStream, encoding);
+                    }
+                }
+            }
+        }
+        return content;
+    }
+
+    @Override
+    public ArtifactMetaData getArtifactMetaData(String artifactId) throws IOException {
+        ArtifactMetaData metadata = null;
+        if (config.getRegistryUrl() != null) {
+            HttpGet get = new HttpGet(String.format("%s/api/artifacts/%s/meta", config.getRegistryUrl(), artifactId));
+            try (CloseableHttpResponse response = httpClient.execute(get)) {
+                if (response.getStatusLine().getStatusCode() >= 200 && response.getStatusLine().getStatusCode() < 300) {
+                    try (InputStream contentStream = response.getEntity().getContent()) {
+                        metadata = mapper.readValue(contentStream, ArtifactMetaData.class);
+                    }
+                }
+            }
+        }
+        return metadata;
+    }
+
+}

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/registry/http/HttpRegistry.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/registry/http/HttpRegistry.java
@@ -29,7 +29,6 @@ public class HttpRegistry implements IRegistry {
     @Inject
     public HttpRegistry(HubConfiguration config) {
         this.registryRestClient = Optional.ofNullable(config.getRegistryUrl())
-                .map(url -> url.endsWith("/") ? url + "api" : url + "/api")
                 .map(RegistryRestClientFactory::create)
                 .orElse(null);
     }

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/registry/http/HttpRegistry.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/registry/http/HttpRegistry.java
@@ -1,19 +1,13 @@
 package io.apicurio.hub.core.registry.http;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.apicurio.hub.core.config.HubConfiguration;
 import io.apicurio.hub.core.registry.IRegistry;
+import io.apicurio.registry.client.RegistryRestClient;
+import io.apicurio.registry.client.RegistryRestClientFactory;
 import io.apicurio.registry.rest.beans.ArtifactMetaData;
 import io.apicurio.registry.rest.beans.ArtifactSearchResults;
 import io.apicurio.registry.rest.beans.SearchedArtifact;
 import org.apache.commons.io.IOUtils;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.entity.ContentType;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
@@ -24,31 +18,28 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 @ApplicationScoped
 @Default
 public class HttpRegistry implements IRegistry {
 
-    private static final Logger logger = LoggerFactory.getLogger(HttpRegistry.class);
-    private static CloseableHttpClient httpClient = HttpClients.createDefault();
-    private static final ObjectMapper mapper = new ObjectMapper();
+    private final RegistryRestClient registryRestClient;
 
     @Inject
-    private HubConfiguration config;
-    
+    public HttpRegistry(HubConfiguration config) {
+        this.registryRestClient = Optional.ofNullable(config.getRegistryUrl())
+                .map(url -> url.endsWith("/") ? url + "api" : url + "/api")
+                .map(RegistryRestClientFactory::create)
+                .orElse(null);
+    }
+
     @Override
-    public Collection<SearchedArtifact> listArtifacts() throws IOException {
+    public Collection<SearchedArtifact> listArtifacts() {
         List<SearchedArtifact> artifactMetaDataList = Collections.emptyList();
-        if (config.getRegistryUrl() != null) {
-            HttpGet get = new HttpGet(String.format("%s/api/search/artifacts", config.getRegistryUrl()));
-            try (CloseableHttpResponse response = httpClient.execute(get)) {
-                if (response.getStatusLine().getStatusCode() >= 200 && response.getStatusLine().getStatusCode() < 300) {
-                    try (InputStream contentStream = response.getEntity().getContent()) {
-                        final ArtifactSearchResults artifactSearchResults = mapper.readValue(contentStream, ArtifactSearchResults.class);
-                        artifactMetaDataList = artifactSearchResults.getArtifacts();
-                    }
-                }
-            }
+        if (registryRestClient != null) {
+            final ArtifactSearchResults artifactSearchResults = registryRestClient.searchArtifacts(null, null, null, null, null);
+            artifactMetaDataList = artifactSearchResults.getArtifacts();
         }
         return artifactMetaDataList;
     }
@@ -56,42 +47,20 @@ public class HttpRegistry implements IRegistry {
     @Override
     public String getArtifact(String artifactId, Integer artifactVersion) throws IOException {
         String content = "";
-        if (config.getRegistryUrl() != null) {
-            StringBuilder urlBuilder = new StringBuilder();
-            urlBuilder.append(config.getRegistryUrl())
-                    .append("/api/artifacts/").append(artifactId);
-            if (artifactVersion != null) {
-                urlBuilder.append("/versions/").append(artifactVersion);
-            }
-            HttpGet get = new HttpGet(urlBuilder.toString());
-            try (CloseableHttpResponse response = httpClient.execute(get)) {
-                if (response.getStatusLine().getStatusCode() >= 200 && response.getStatusLine().getStatusCode() < 300) {
-                    try (InputStream contentStream = response.getEntity().getContent()) {
-                        ContentType ct = ContentType.getOrDefault(response.getEntity());
-                        String encoding = StandardCharsets.UTF_8.name();
-                        if (ct != null && ct.getCharset() != null) {
-                            encoding = ct.getCharset().name();
-                        }
-                        content = IOUtils.toString(contentStream, encoding);
-                    }
-                }
+        if (registryRestClient != null) {
+            try (InputStream contentStream = registryRestClient.getArtifactVersion(artifactId, artifactVersion)) {
+                String encoding = StandardCharsets.UTF_8.name();
+                content = IOUtils.toString(contentStream, encoding);
             }
         }
         return content;
     }
 
     @Override
-    public ArtifactMetaData getArtifactMetaData(String artifactId) throws IOException {
+    public ArtifactMetaData getArtifactMetaData(String artifactId) {
         ArtifactMetaData metadata = null;
-        if (config.getRegistryUrl() != null) {
-            HttpGet get = new HttpGet(String.format("%s/api/artifacts/%s/meta", config.getRegistryUrl(), artifactId));
-            try (CloseableHttpResponse response = httpClient.execute(get)) {
-                if (response.getStatusLine().getStatusCode() >= 200 && response.getStatusLine().getStatusCode() < 300) {
-                    try (InputStream contentStream = response.getEntity().getContent()) {
-                        metadata = mapper.readValue(contentStream, ArtifactMetaData.class);
-                    }
-                }
-            }
+        if (registryRestClient != null) {
+            metadata = registryRestClient.getArtifactMetaData(artifactId);
         }
         return metadata;
     }

--- a/front-end/servlet/src/main/java/io/apicurio/studio/fe/servlet/config/StudioUiConfiguration.java
+++ b/front-end/servlet/src/main/java/io/apicurio/studio/fe/servlet/config/StudioUiConfiguration.java
@@ -54,6 +54,9 @@ public class StudioUiConfiguration extends Configuration {
     private static final String FEATURE_SHARE_WITH_EVERYONE_ENV = "APICURIO_UI_FEATURE_SHARE_WITH_EVERYONE";
     private static final String FEATURE_SHARE_WITH_EVERYONE_SYSPROP = "apicurio-ui.feature.shareWithEveryone";
 
+    private static final String REGISTRY_UI_URL_ENV = "APICURIO_REGISTRY_UI_URL";
+    private static final String REGISTRY_UI_URL_SYSPROP = "apicurio.registry.ui.url";
+
     /**
      * Returns the URL of the Apicurio Hub API.
      */
@@ -117,6 +120,13 @@ public class StudioUiConfiguration extends Configuration {
      */
     public String getUiUrl() {
         return getConfigurationProperty(HUB_UI_URL_ENV, HUB_UI_URL_SYSPROP, null);
+    }
+
+    /**
+     * @return the URL of the Apicurio Registry Instance's UI.
+     */
+    public String getRegistryUiUrl() {
+        return getConfigurationProperty(REGISTRY_UI_URL_ENV, REGISTRY_UI_URL_SYSPROP, null);
     }
 
 }

--- a/front-end/servlet/src/main/java/io/apicurio/studio/fe/servlet/servlets/StudioConfigServlet.java
+++ b/front-end/servlet/src/main/java/io/apicurio/studio/fe/servlet/servlets/StudioConfigServlet.java
@@ -112,7 +112,7 @@ public class StudioConfigServlet extends HttpServlet {
             config.getUi().setUrl(this.uiConfig.getUiUrl());
 
             config.setRegistry(new StudioConfigRegistry());
-            config.getRegistry().setUrl(uiConfig.getRegistryUrl());
+            config.getRegistry().setUiUrl(uiConfig.getRegistryUiUrl());
             
             config.setFeatures(new StudioConfigFeatures());
             config.getFeatures().setMicrocks(uiConfig.isMicrocksEnabled());

--- a/front-end/servlet/src/main/java/io/apicurio/studio/fe/servlet/servlets/StudioConfigServlet.java
+++ b/front-end/servlet/src/main/java/io/apicurio/studio/fe/servlet/servlets/StudioConfigServlet.java
@@ -28,6 +28,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+import io.apicurio.studio.shared.beans.StudioConfigRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,6 +110,9 @@ public class StudioConfigServlet extends HttpServlet {
             
             config.setUi(new StudioConfigUi());
             config.getUi().setUrl(this.uiConfig.getUiUrl());
+
+            config.setRegistry(new StudioConfigRegistry());
+            config.getRegistry().setUrl(uiConfig.getRegistryUrl());
             
             config.setFeatures(new StudioConfigFeatures());
             config.getFeatures().setMicrocks(uiConfig.isMicrocksEnabled());

--- a/front-end/studio/src/app/app.module.ts
+++ b/front-end/studio/src/app/app.module.ts
@@ -77,6 +77,7 @@ import {DownloadDialogComponent} from "./pages/apis/{apiId}/_components/download
 import {ImportComponentsWizard} from "./pages/apis/{apiId}/_components/import-components.wizard";
 import {DataTableComponent} from "./components/common/data-table.component";
 import {LoadingComponent} from "./components/common/loading.component";
+import {ArtifactsService} from "./services/artifacts.service";
 
 @NgModule({
     imports: [
@@ -97,7 +98,7 @@ import {LoadingComponent} from "./components/common/loading.component";
         DataTableComponent, LoadingComponent
     ],
     providers: [
-        ApisService, AuthenticationServiceProvider, ConfigService, LinkedAccountsService, ValidationService,
+        ApisService, ArtifactsService, AuthenticationServiceProvider, ConfigService, LinkedAccountsService, ValidationService,
         AuthenticationCanActivateGuard, ApiEditorPageGuard, CurrentUserService, TemplateService
     ],
     bootstrap: [AppComponent]

--- a/front-end/studio/src/app/models/api.model.ts
+++ b/front-end/studio/src/app/models/api.model.ts
@@ -25,6 +25,7 @@ export class Api {
     createdBy: string;
     tags: string[];
     type: string;
+    __resourceType: string;
 
     constructor() {
         this.id = "";
@@ -34,6 +35,7 @@ export class Api {
         this.createdBy = "";
         this.tags = null;
         this.type = "";
+        this.__resourceType = "API";
     }
 
 }
@@ -55,6 +57,7 @@ export class ApiDefinition extends Api {
         apiDef.description = api.description;
         apiDef.createdOn = api.createdOn;
         apiDef.createdBy = api.createdBy;
+        apiDef.__resourceType = api.__resourceType;
 
         return apiDef;
     }
@@ -81,6 +84,7 @@ export class EditableApiDefinition extends ApiDefinition {
         apiDef.createdOn = api.createdOn;
         apiDef.createdBy = api.createdBy;
         apiDef.type = api.type;
+        apiDef.__resourceType = api.__resourceType;
 
         return apiDef;
     }

--- a/front-end/studio/src/app/models/artifact.model.ts
+++ b/front-end/studio/src/app/models/artifact.model.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2020 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+// tslint:disable-next-line:interface-name
+export class Artifact {
+
+    id: string;
+    type: string;
+    state: string;
+    name: string;
+    version: number;
+    description: string;
+    labels: string[];
+    createdOn: Date;
+    createdBy: string;
+    modifiedOn: Date;
+    modifiedBy: string;
+
+    constructor() {
+        this.id = "";
+        this.type = "";
+        this.state = ""
+        this.name = "";
+        this.version = 1;
+        this.description = "";
+        this.labels = null;
+        this.createdOn = new Date();
+        this.createdBy = "";
+        this.modifiedOn = new Date();
+        this.modifiedBy = "";
+    }
+
+}
+
+export class ArtifactDefinition extends Artifact {
+
+    spec: any;
+
+    constructor() {
+        super();
+        this.spec = {};
+    }
+
+    public static fromArtifact(artifact: Artifact): ArtifactDefinition {
+        let artifactDefinition: ArtifactDefinition = new ArtifactDefinition();
+        artifactDefinition.id = artifact.id;
+        artifactDefinition.type = artifact.type;
+        artifactDefinition.state = artifact.state;
+        artifactDefinition.name = artifact.name;
+        artifactDefinition.version = artifact.version;
+        artifactDefinition.description = artifact.description;
+        artifactDefinition.labels = artifact.labels;
+        artifactDefinition.createdOn = artifact.createdOn;
+        artifactDefinition.createdBy = artifact.createdBy;
+        artifactDefinition.modifiedOn = artifact.modifiedOn;
+        artifactDefinition.modifiedBy = artifact.modifiedBy;
+
+        return artifactDefinition;
+    }
+
+}

--- a/front-end/studio/src/app/models/artifact.model.ts
+++ b/front-end/studio/src/app/models/artifact.model.ts
@@ -30,6 +30,7 @@ export class Artifact {
     createdBy: string;
     modifiedOn: Date;
     modifiedBy: string;
+    __resourceType: string;
 
     constructor() {
         this.id = "";
@@ -43,6 +44,7 @@ export class Artifact {
         this.createdBy = "";
         this.modifiedOn = new Date();
         this.modifiedBy = "";
+        this.__resourceType = "ARTIFACT";
     }
 
 }
@@ -69,6 +71,7 @@ export class ArtifactDefinition extends Artifact {
         artifactDefinition.createdBy = artifact.createdBy;
         artifactDefinition.modifiedOn = artifact.modifiedOn;
         artifactDefinition.modifiedBy = artifact.modifiedBy;
+        artifactDefinition.__resourceType = artifact.__resourceType;
 
         return artifactDefinition;
     }

--- a/front-end/studio/src/app/pages/apis/{apiId}/_components/import-components.wizard.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/_components/import-components.wizard.html
@@ -39,9 +39,9 @@
                         <!-- Resources -->
                         <div class="wizard-pf-contents" *ngIf="currentPage === 'resources'">
                             <p>Choose one or more component source from the list below.</p>
-                            <data-table *ngIf="!loadingApis" [pageSize]="10" [columns]="apiColumns" [rows]="apiRows"
+                            <data-table *ngIf="!loadingResources" [pageSize]="10" [columns]="apiColumns" [rows]="apiRows"
                                         [(selectedValues)]="selectedResources" (onChange)="mustLoadComponents=true"></data-table>
-                            <p *ngIf="loadingApis">
+                            <p *ngIf="loadingResources">
                                 <loading message="Please wait, loading list of resources..."></loading>
                             </p>
                         </div>

--- a/front-end/studio/src/app/pages/apis/{apiId}/_components/import-components.wizard.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/_components/import-components.wizard.html
@@ -40,7 +40,7 @@
                         <div class="wizard-pf-contents" *ngIf="currentPage === 'resources'">
                             <p>Choose one or more component source from the list below.</p>
                             <data-table *ngIf="!loadingApis" [pageSize]="10" [columns]="apiColumns" [rows]="apiRows"
-                                        [(selectedValues)]="selectedApis" (onChange)="mustLoadComponents=true"></data-table>
+                                        [(selectedValues)]="selectedResources" (onChange)="mustLoadComponents=true"></data-table>
                             <p *ngIf="loadingApis">
                                 <loading message="Please wait, loading list of resources..."></loading>
                             </p>

--- a/front-end/studio/src/app/pages/apis/{apiId}/_components/import-components.wizard.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/_components/import-components.wizard.ts
@@ -19,7 +19,6 @@ import {Component, QueryList, ViewChildren} from "@angular/core";
 import {ModalDirective} from "ngx-bootstrap";
 import {ApisService} from "../../../../services/apis.service";
 import {ArtifactsService} from "../../../../services/artifacts.service";
-import {ConfigService} from "../../../../services/config.service";
 import {ImportedComponent} from "../editor/_models/imported-component.model";
 import {Api, ApiDefinition} from "../../../../models/api.model";
 import {Artifact, ArtifactDefinition} from "../../../../models/artifact.model";
@@ -80,8 +79,7 @@ export class ImportComponentsWizard {
      * @param config
      */
     constructor(private apis: ApisService,
-                private artifacts: ArtifactsService,
-                private config: ConfigService) {}
+                private artifacts: ArtifactsService) {}
 
     /**
      * Called to open the wizard.
@@ -110,11 +108,10 @@ export class ImportComponentsWizard {
         this.currentPage = "resources";
 
 
-        let promises: Promise<(Api|Artifact)[]>[] = [];
-        promises.push(this.apis.getApis());
-        if (this.config.registryUrl() !== "") {
-            promises.push(this.artifacts.getArtifacts());
-        }
+        let promises: Promise<(Api|Artifact)[]>[] = [
+            this.apis.getApis(),
+            this.artifacts.getArtifacts()
+        ];
 
         this.allResources = [];
         Promise.all(promises).then(allResources => {
@@ -401,9 +398,9 @@ export class ImportComponentsWizard {
     private getArtifactComponents(artifactDefinition: ArtifactDefinition, doc: Document): ImportedComponent[] {
         let finder: ArtifactComponentFinder;
         if (doc.getDocumentType() == DocumentType.openapi2) {
-            finder = new Oas20ArtifactComponentFinder(artifactDefinition, this.type, this.config.registryUrl());
+            finder = new Oas20ArtifactComponentFinder(artifactDefinition, this.type);
         } else {
-            finder = new ArtifactComponentFinder(artifactDefinition, this.type, this.config.registryUrl());
+            finder = new ArtifactComponentFinder(artifactDefinition, this.type);
         }
         Library.visitTree(doc, finder, TraverserDirection.down);
         return finder.foundComponents;
@@ -520,7 +517,7 @@ class ArtifactComponentFinder extends CombinedVisitorAdapter {
 
     public foundComponents: ImportedComponent[] = [];
 
-    constructor(protected artifactDefinition: ArtifactDefinition, protected type: ComponentType, protected registryUrl: string) {
+    constructor(protected artifactDefinition: ArtifactDefinition, protected type: ComponentType) {
         super();
     }
 
@@ -590,8 +587,8 @@ class ArtifactComponentFinder extends CombinedVisitorAdapter {
 }
 class Oas20ArtifactComponentFinder extends ArtifactComponentFinder {
 
-    constructor(artifactDefinition: ArtifactDefinition, type: ComponentType, registryUrl: string) {
-        super(artifactDefinition, type, registryUrl);
+    constructor(artifactDefinition: ArtifactDefinition, type: ComponentType) {
+        super(artifactDefinition, type);
     }
 
     protected getFragmentPrefix(): string {

--- a/front-end/studio/src/app/pages/apis/{apiId}/_components/import-components.wizard.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/_components/import-components.wizard.ts
@@ -321,19 +321,20 @@ export class ImportComponentsWizard {
         this.components = [];
         console.debug("[ImportComponentsWizard] Loading components from %o resources.", this.selectedResources.length);
         let promises: Promise<ApiDefinition | ArtifactDefinition>[] = this.selectedResources.map(apiOrArtifact => {
-            // TODO find a better way to route the processing flow (instanceof does not work)
-            if (["OPENAPI", "ASYNCAPI", "JSON"].includes(apiOrArtifact.type)) {
+            if ("ARTIFACT" === apiOrArtifact.__resourceType) {
                 console.debug("[ImportComponentsWizard] Loading artifact definition for: ", apiOrArtifact.name);
                 return this.artifacts.getArtifactDefinition(apiOrArtifact.id).then(artifactDef => {
                     this.processLoadedArtifactDef(artifactDef);
                     return artifactDef;
                 });
-            } else {
+            } else if ("API" === apiOrArtifact.__resourceType) {
                 console.debug("[ImportComponentsWizard] Loading api definition for: ", apiOrArtifact.name);
                 return this.apis.getApiDefinition(apiOrArtifact.id).then(apiDef => {
                     this.processLoadedApiDef(apiDef);
                     return apiDef;
                 });
+            } else {
+                console.warn("[ImportComponentsWizard] Missing __resourceType field for resource named", apiOrArtifact.name);
             }
         });
         Promise.all(promises).then(() => {

--- a/front-end/studio/src/app/pages/apis/{apiId}/_components/import-components.wizard.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/_components/import-components.wizard.ts
@@ -49,14 +49,14 @@ export class ImportComponentsWizard {
     protected _isOpen: boolean = false;
 
     loading: boolean;
-    loadingApis: boolean;
+    loadingResources: boolean;
     loadingComponents: boolean;
     currentPage: string;
 
     type: ComponentType;
 
     private result: Promise<ImportedComponent[]>;
-    private allResources: (Api | Artifact)[]; // TODO are type unions a bad way to handle this?
+    private allResources: (Api | Artifact)[];
     selectedResources: (Api | Artifact)[];
     mustLoadComponents: boolean = false;
     private components: ImportedComponent[];
@@ -105,7 +105,7 @@ export class ImportComponentsWizard {
                 this.importComponentsModal.first.show();
             }
         });
-        this.loadingApis = true;
+        this.loadingResources = true;
         this.loading = true;
         this.currentPage = "resources";
 
@@ -118,17 +118,17 @@ export class ImportComponentsWizard {
 
         this.allResources = [];
         Promise.all(promises).then(allResources => {
-            console.debug("[ImportComponentsWizardComponent] APIs loaded.");
+            console.debug("[ImportComponentsWizardComponent] Resources loaded.");
             allResources.forEach(resourcePartition => this.allResources.push(...resourcePartition))
             this.apiRows = this.resourceTableRows();
             this.loading = false;
-            this.loadingApis = false;
+            this.loadingResources = false;
         }).catch(error => {
-            console.error("[ImportComponentsWizardComponent] Error getting APIs");
+            console.error("[ImportComponentsWizardComponent] Error getting resources");
             this.error = error;
-            this.errorMessage = "Error getting your APIs.";
+            this.errorMessage = "Error getting your resources.";
             this.loading = false;
-            this.loadingApis = false;
+            this.loadingResources = false;
         });
 
         this.result = new Promise<ImportedComponent[]>((resolve, reject) => {

--- a/front-end/studio/src/app/pages/apis/{apiId}/_components/import-components.wizard.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/_components/import-components.wizard.ts
@@ -18,8 +18,11 @@
 import {Component, QueryList, ViewChildren} from "@angular/core";
 import {ModalDirective} from "ngx-bootstrap";
 import {ApisService} from "../../../../services/apis.service";
+import {ArtifactsService} from "../../../../services/artifacts.service";
+import {ConfigService} from "../../../../services/config.service";
 import {ImportedComponent} from "../editor/_models/imported-component.model";
 import {Api, ApiDefinition} from "../../../../models/api.model";
+import {Artifact, ArtifactDefinition} from "../../../../models/artifact.model";
 import {ComponentType} from "../editor/_models/component-type.model";
 import {DataTableColumn, DataTableRow} from "../../../../components/common/data-table.component";
 import * as moment from "moment";
@@ -53,8 +56,8 @@ export class ImportComponentsWizard {
     type: ComponentType;
 
     private result: Promise<ImportedComponent[]>;
-    private allApis: Api[];
-    selectedApis: Api[];
+    private allResources: (Api | Artifact)[]; // TODO are type unions a bad way to handle this?
+    selectedResources: (Api | Artifact)[];
     mustLoadComponents: boolean = false;
     private components: ImportedComponent[];
     selectedComponents: ImportedComponent[];
@@ -73,8 +76,12 @@ export class ImportComponentsWizard {
     /**
      * Constructor with injection!
      * @param apis
+     * @param artifacts
+     * @param config
      */
-    constructor(private apis: ApisService) {}
+    constructor(private apis: ApisService,
+                private artifacts: ArtifactsService,
+                private config: ConfigService) {}
 
     /**
      * Called to open the wizard.
@@ -83,8 +90,8 @@ export class ImportComponentsWizard {
         this._isOpen = true;
 
         this.type = type;
-        this.allApis = [];
-        this.selectedApis = [];
+        this.allResources = [];
+        this.selectedResources = [];
         this.components = [];
         this.selectedComponents = [];
 
@@ -102,9 +109,17 @@ export class ImportComponentsWizard {
         this.loading = true;
         this.currentPage = "resources";
 
-        this.apis.getApis().then( apis => {
+
+        let promises: Promise<(Api|Artifact)[]>[] = [];
+        promises.push(this.apis.getApis());
+        if (this.config.registryUrl() !== "") {
+            promises.push(this.artifacts.getArtifacts());
+        }
+
+        this.allResources = [];
+        Promise.all(promises).then(allResources => {
             console.debug("[ImportComponentsWizardComponent] APIs loaded.");
-            this.allApis = apis;
+            allResources.forEach(resourcePartition => this.allResources.push(...resourcePartition))
             this.apiRows = this.resourceTableRows();
             this.loading = false;
             this.loadingApis = false;
@@ -139,7 +154,7 @@ export class ImportComponentsWizard {
 
     /**
      * Returns true if the wizard is open.
-     * 
+     *
      */
     public isOpen(): boolean {
         return this._isOpen;
@@ -167,7 +182,7 @@ export class ImportComponentsWizard {
 
     public isPageValid(page: string): boolean {
         if (page === "resources") {
-            return this.selectedApis.length > 0;
+            return this.selectedResources.length > 0;
         }
         if (page === "components") {
             return this.selectedComponents.length > 0;
@@ -289,14 +304,14 @@ export class ImportComponentsWizard {
     }
 
     private resourceTableRows(): DataTableRow[] {
-        return this.allApis.map(api => {
+        return this.allResources.map(apiOrArtifact => {
             return {
-                value: api,
+                value: apiOrArtifact,
                 cells: [
-                    { displayName: api.name },
-                    { displayName: api.description },
-                    { displayName: api.type },
-                    { displayName: moment(api.createdOn).fromNow() }
+                    { displayName: apiOrArtifact.name },
+                    { displayName: apiOrArtifact.description },
+                    { displayName: apiOrArtifact.type },
+                    { displayName: moment(apiOrArtifact.createdOn).fromNow() }
                 ]
             };
         });
@@ -304,13 +319,22 @@ export class ImportComponentsWizard {
 
     private loadComponents(): void {
         this.components = [];
-        console.debug("[ImportComponentsWizard] Loading components from %o resources.", this.selectedApis.length);
-        let promises: Promise<ApiDefinition>[] = this.selectedApis.map( api => {
-            console.debug("[ImportComponentsWizard] Loading api definition for: ", api.name);
-            return this.apis.getApiDefinition(api.id).then(apiDef => {
-                this.processLoadedApiDef(apiDef);
-                return apiDef;
-            });
+        console.debug("[ImportComponentsWizard] Loading components from %o resources.", this.selectedResources.length);
+        let promises: Promise<ApiDefinition | ArtifactDefinition>[] = this.selectedResources.map(apiOrArtifact => {
+            // TODO find a better way to route the processing flow (instanceof does not work)
+            if (["OPENAPI", "ASYNCAPI", "JSON"].includes(apiOrArtifact.type)) {
+                console.debug("[ImportComponentsWizard] Loading artifact definition for: ", apiOrArtifact.name);
+                return this.artifacts.getArtifactDefinition(apiOrArtifact.id).then(artifactDef => {
+                    this.processLoadedArtifactDef(artifactDef);
+                    return artifactDef;
+                });
+            } else {
+                console.debug("[ImportComponentsWizard] Loading api definition for: ", apiOrArtifact.name);
+                return this.apis.getApiDefinition(apiOrArtifact.id).then(apiDef => {
+                    this.processLoadedApiDef(apiDef);
+                    return apiDef;
+                });
+            }
         });
         Promise.all(promises).then(() => {
             console.debug("[ImportComponentsWizard] All resources loaded successfully.");
@@ -342,12 +366,43 @@ export class ImportComponentsWizard {
         });
     }
 
+    private processLoadedArtifactDef(artifactDefinition: ArtifactDefinition): void {
+        console.debug("[ImportComponentsWizard] Processing an Artifact def: ", artifactDefinition.name);
+        // TODO see details in loadComponents about the use of hardcoded registry types
+        if (artifactDefinition.type === "JSON") {
+            let $ref: string = `${ this.config.registryUrl() }/api/artifacts/${ artifactDefinition.id }/versions/${ artifactDefinition.version }#`;
+            this.components.push({
+                name: artifactDefinition.name,
+                $ref: $ref,
+                type: ComponentType.schema
+            });
+        } else if (artifactDefinition.type === "ASYNCAPI" || artifactDefinition.type === "OPENAPI") {
+            let doc: Document = Library.readDocument(artifactDefinition.spec);
+            let components: ImportedComponent[] = this.getArtifactComponents(artifactDefinition, doc);
+            components.forEach(component => {
+                this.components.push(component);
+            });
+        }
+        console.debug("[ImportComponentsWizard] Done processing Artifact def:", artifactDefinition.name);
+    }
+
     private getComponents(apiDef: ApiDefinition, doc: Document): ImportedComponent[] {
         let finder: ComponentFinder;
         if (doc.getDocumentType() == DocumentType.openapi2) {
             finder = new Oas20ComponentFinder(apiDef, this.type);
         } else {
             finder = new ComponentFinder(apiDef, this.type);
+        }
+        Library.visitTree(doc, finder, TraverserDirection.down);
+        return finder.foundComponents;
+    }
+
+    private getArtifactComponents(artifactDefinition: ArtifactDefinition, doc: Document): ImportedComponent[] {
+        let finder: ArtifactComponentFinder;
+        if (doc.getDocumentType() == DocumentType.openapi2) {
+            finder = new Oas20ArtifactComponentFinder(artifactDefinition, this.type, this.config.registryUrl());
+        } else {
+            finder = new ArtifactComponentFinder(artifactDefinition, this.type, this.config.registryUrl());
         }
         Library.visitTree(doc, finder, TraverserDirection.down);
         return finder.foundComponents;
@@ -444,6 +499,98 @@ class Oas20ComponentFinder extends ComponentFinder {
 
     constructor(apiDef: ApiDefinition, type: ComponentType) {
         super(apiDef, type);
+    }
+
+    protected getFragmentPrefix(): string {
+        switch (this.type) {
+            case ComponentType.schema:
+                return "#/definitions/";
+            case ComponentType.response:
+                return "#/responses/";
+            case ComponentType.parameter:
+                return "#/parameters/";
+            case ComponentType.securityScheme:
+                return "#/securityDefinitions/";
+        }
+    }
+}
+
+class ArtifactComponentFinder extends CombinedVisitorAdapter {
+
+    public foundComponents: ImportedComponent[] = [];
+
+    constructor(protected artifactDefinition: ArtifactDefinition, protected type: ComponentType, protected registryUrl: string) {
+        super();
+    }
+
+    protected componentFound(definition: IDefinition): void {
+        this.foundComponents.push(this.toImportedComponent(definition));
+    }
+
+    protected toImportedComponent(definition: IDefinition): ImportedComponent {
+        let $ref: string = `${this.registryUrl}/api/artifacts/${ this.artifactDefinition.id }/versions/${ this.artifactDefinition.version }${ this.getFragmentPrefix() + definition.getName() }`;
+        let component: ImportedComponent = {
+            name: definition.getName(),
+            $ref: $ref,
+            type: this.type,
+            from: {
+                name: this.artifactDefinition.name,
+                id: this.artifactDefinition.id
+            }
+        };
+        return component;
+    }
+
+    protected getFragmentPrefix(): string {
+        if (this.artifactDefinition.type === "JSON") {
+            return "#/";
+        }
+        switch (this.type) {
+            case ComponentType.schema:
+                return "#/components/schemas/";
+            case ComponentType.response:
+                return "#/components/responses/";
+            case ComponentType.parameter:
+                return "#/components/parameters/";
+            case ComponentType.header:
+                return "#/components/headers/";
+            case ComponentType.requestBody:
+                return "#/components/requestBodies/";
+            case ComponentType.callback:
+                return "#/components/callbacks/";
+            case ComponentType.example:
+                return "#/components/examples/";
+            case ComponentType.securityScheme:
+                return "#/components/securitySchemes/";
+            case ComponentType.link:
+                return "#/components/links/";
+            case ComponentType.messageTrait:
+                return "#/components/messageTraits";
+        }
+    }
+
+    visitSchemaDefinition(node: IDefinition): void {
+        if (this.type == ComponentType.schema) {
+            this.componentFound(node);
+        }
+    }
+
+    visitResponseDefinition(node: IDefinition): void {
+        if (this.type == ComponentType.response) {
+            this.componentFound(node);
+        }
+    }
+
+    visitMessageTraitDefinition(node: IDefinition): void {
+        if (this.type == ComponentType.messageTrait) {
+            this.componentFound(node);
+        }
+    }
+}
+class Oas20ArtifactComponentFinder extends ArtifactComponentFinder {
+
+    constructor(artifactDefinition: ArtifactDefinition, type: ComponentType, registryUrl: string) {
+        super(artifactDefinition, type, registryUrl);
     }
 
     protected getFragmentPrefix(): string {

--- a/front-end/studio/src/app/pages/apis/{apiId}/_components/import-components.wizard.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/_components/import-components.wizard.ts
@@ -369,9 +369,9 @@ export class ImportComponentsWizard {
 
     private processLoadedArtifactDef(artifactDefinition: ArtifactDefinition): void {
         console.debug("[ImportComponentsWizard] Processing an Artifact def: ", artifactDefinition.name);
-        // TODO see details in loadComponents about the use of hardcoded registry types
-        if (artifactDefinition.type === "JSON") {
-            let $ref: string = `${ this.config.registryUrl() }/api/artifacts/${ artifactDefinition.id }/versions/${ artifactDefinition.version }#`;
+        // TODO handle the other registry types as well
+        if (this.type === ComponentType.schema && artifactDefinition.type === "JSON") {
+            let $ref: string = `apicurio-registry:${ artifactDefinition.id }/${ artifactDefinition.version }#`;
             this.components.push({
                 name: artifactDefinition.name,
                 $ref: $ref,
@@ -529,7 +529,7 @@ class ArtifactComponentFinder extends CombinedVisitorAdapter {
     }
 
     protected toImportedComponent(definition: IDefinition): ImportedComponent {
-        let $ref: string = `${this.registryUrl}/api/artifacts/${ this.artifactDefinition.id }/versions/${ this.artifactDefinition.version }${ this.getFragmentPrefix() + definition.getName() }`;
+        let $ref: string = `apicurio-registry:${ this.artifactDefinition.id }/${ this.artifactDefinition.version }${ this.getFragmentPrefix() + definition.getName() }`;
         let component: ImportedComponent = {
             name: definition.getName(),
             $ref: $ref,

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/definition-form.component.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/definition-form.component.html
@@ -130,7 +130,8 @@
                          [validationShallow]="true">
                     <div body>
                         <span>This Data Type is an external reference to: </span>
-                        <em><a [href]="refLink()" target="_blank"><span class="fa fa-fw fa-external-link"></span>{{ definition.$ref }}</a></em>
+                        <em *ngIf="shouldRenderLink()"><a [href]="refLink()" target="_blank"><span class="fa fa-fw fa-external-link"></span>{{ definition.$ref }}</a></em>
+                        <em *ngIf="!shouldRenderLink()">{{ definition.$ref }}</em>
                     </div>
                 </section>
                 <!-- Reference Details -->

--- a/front-end/studio/src/app/services/apis.service.ts
+++ b/front-end/studio/src/app/services/apis.service.ts
@@ -396,6 +396,7 @@ export class ApisService extends AbstractHubService {
 
         console.info("[ApisService] Fetching API list: %s", listApisUrl);
         return this.httpGet<Api[]>(listApisUrl, options, (apis) => {
+            apis.forEach(api => api.__resourceType = "API")
             this.cachedApis = apis;
             return apis;
         });

--- a/front-end/studio/src/app/services/artifacts.service.ts
+++ b/front-end/studio/src/app/services/artifacts.service.ts
@@ -47,7 +47,7 @@ export class ArtifactsService extends AbstractHubService {
      * @see ArtifactsService.getArtifacts
      */
     public getArtifacts(): Promise<Artifact[]> {
-        console.info("[ApisService] Getting all Artifacts");
+        console.info("[ArtifactsService] Getting all Artifacts");
 
         let listArtifactsUrl: string = this.endpoint("/registry");
         let options: any = this.options({ "Accept": "application/json" });

--- a/front-end/studio/src/app/services/artifacts.service.ts
+++ b/front-end/studio/src/app/services/artifacts.service.ts
@@ -54,6 +54,7 @@ export class ArtifactsService extends AbstractHubService {
 
         console.info("[ArtifactsService] Fetching Artifact list: %s", listArtifactsUrl);
         return this.httpGet<Artifact[]>(listArtifactsUrl, options, (artifacts) => {
+            artifacts.forEach(artifact => artifact.__resourceType = "ARTIFACT")
             this.cachedArtifacts = artifacts;
             return artifacts;
         });

--- a/front-end/studio/src/app/services/artifacts.service.ts
+++ b/front-end/studio/src/app/services/artifacts.service.ts
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {AbstractHubService} from "./hub";
+import {HttpClient, HttpResponse} from "@angular/common/http";
+import {ConfigService} from "./config.service";
+import {IAuthenticationService} from "./auth.service";
+import {Injectable} from "@angular/core";
+import {HttpUtils} from "../util/common";
+import {Artifact, ArtifactDefinition} from "../models/artifact.model";
+
+
+/**
+ * An implementation of the Artifacts service that uses the Apicurio Studio back-end (Hub API) service
+ * to reach the configured registry.
+ */
+@Injectable()
+export class ArtifactsService extends AbstractHubService {
+
+    private cachedArtifacts: Artifact[] = null;
+
+    /**
+     * Constructor.
+     * @param http
+     * @param authService
+     * @param config
+     */
+    constructor(http: HttpClient, authService: IAuthenticationService, config: ConfigService) {
+        super(http, authService, config);
+    }
+
+    /**
+     * @see ArtifactsService.getArtifacts
+     */
+    public getArtifacts(): Promise<Artifact[]> {
+        console.info("[ApisService] Getting all Artifacts");
+
+        let listArtifactsUrl: string = this.endpoint("/registry");
+        let options: any = this.options({ "Accept": "application/json" });
+
+        console.info("[ArtifactsService] Fetching Artifact list: %s", listArtifactsUrl);
+        return this.httpGet<Artifact[]>(listArtifactsUrl, options, (artifacts) => {
+            this.cachedArtifacts = artifacts;
+            return artifacts;
+        });
+    }
+
+    /**
+     * @see ArtifactsService.getArtifact
+     */
+    public getArtifact(artifactId: string): Promise<Artifact> {
+        let getArtifactUrl: string = this.endpoint("/registry/:artifactId", {
+            artifactId: artifactId
+        });
+        let options: any = this.options({ "Accept": "application/json" });
+
+        console.info("[ArtifactsService] Getting an Artifact: %s", getArtifactUrl);
+        return this.httpGet<Artifact>(getArtifactUrl, options);
+    }
+
+    /**
+     * @see ArtifactsService.getArtifactDefinition
+     */
+    public getArtifactDefinition(artifactId: string): Promise<ArtifactDefinition> {
+        return this.getArtifact(artifactId).then(artifact => {
+            let getContentUrl: string = this.endpoint("/registry/:artifactId/:artifactVersion/content", {
+                artifactId: artifactId,
+                artifactVersion: artifact.version
+            });
+            let options: any = this.options({ "Accept": "application/json" });
+            if (artifact.type == "GRAPHQL") {
+                console.info("[ArtifactsService] Getting GraphQL content!");
+                options = this.options({ "Accept": "application/graphql" });
+                options["responseType"] = "text";
+            }
+            console.info("[ArtifactsService] Getting Artifact content: %s", getContentUrl);
+            options["observe"] = "response";
+            return HttpUtils.mappedPromise(this.http.get<HttpResponse<any>>(getContentUrl, options).toPromise(), response => {
+                let artifactSpec: any = response.body;
+                let artifactDefinition: ArtifactDefinition = ArtifactDefinition.fromArtifact(artifact);
+                artifactDefinition.spec = artifactSpec;
+                return artifactDefinition;
+            });
+        });
+    }
+
+}

--- a/front-end/studio/src/app/services/artifacts.service.ts
+++ b/front-end/studio/src/app/services/artifacts.service.ts
@@ -99,4 +99,18 @@ export class ArtifactsService extends AbstractHubService {
         });
     }
 
+    /**
+     * @see ArtifactsService.getArtifactContentForVersion
+     */
+    public getArtifactContentForVersion(artifactId: string, artifactVersion: string): Promise<any> {
+        let getContentUrl: string = this.endpoint("/registry/:artifactId/:artifactVersion/content", {
+            artifactId: artifactId,
+            artifactVersion: artifactVersion
+        });
+        let options: any = this.options({ "Accept": "application/json" });
+
+        console.info("[ArtifactsService] Getting Artifact content: %s", getContentUrl);
+        return this.httpGet<any>(getContentUrl, options);
+    }
+
 }

--- a/front-end/studio/src/app/services/config.service.ts
+++ b/front-end/studio/src/app/services/config.service.ts
@@ -32,7 +32,7 @@ let DEFAULT_CONFIG: any = {
         uiUrl: "http://localhost:8080/studio/"
     },
     registry: {
-        registryUrl: "http://localhost:8080/registry/"
+        uiUrl: "http://localhost:8080/registry/ui"
     },
     features: {
         "microcks": true,
@@ -150,11 +150,11 @@ export class ConfigService {
         return this.config.ui.url;
     }
 
-    public registryUrl(): string {
-        if (!this.config.registry || !this.config.registry.url) {
+    public registryUiUrl(): string {
+        if (!this.config.registry || !this.config.registry.uiUrl) {
             return "";
         }
-        return this.config.registry.url;
+        return this.config.registry.uiUrl;
     }
 
     public isShareWithEveryoneEnabled(): boolean {

--- a/front-end/studio/src/app/services/config.service.ts
+++ b/front-end/studio/src/app/services/config.service.ts
@@ -31,6 +31,9 @@ let DEFAULT_CONFIG: any = {
     ui: {
         uiUrl: "http://localhost:8080/studio/"
     },
+    registry: {
+        registryUrl: "http://localhost:8080/registry/"
+    },
     features: {
         "microcks": true,
         "graphql": true,
@@ -145,6 +148,13 @@ export class ConfigService {
             return "";
         }
         return this.config.ui.url;
+    }
+
+    public registryUrl(): string {
+        if (!this.config.registry || !this.config.registry.url) {
+            return "";
+        }
+        return this.config.registry.url;
     }
 
     public isShareWithEveryoneEnabled(): boolean {

--- a/shared/beans/src/main/java/io/apicurio/studio/shared/beans/StudioConfig.java
+++ b/shared/beans/src/main/java/io/apicurio/studio/shared/beans/StudioConfig.java
@@ -33,6 +33,7 @@ public class StudioConfig {
     private User user;
     private StudioConfigUi ui;
     private StudioConfigFeatures features;
+    private StudioConfigRegistry registry;
     
     /**
      * Constructor.
@@ -122,6 +123,20 @@ public class StudioConfig {
      */
     public void setUi(StudioConfigUi ui) {
         this.ui = ui;
+    }
+
+    /**
+     * @return the registry
+     */
+    public StudioConfigRegistry getRegistry() {
+        return registry;
+    }
+
+    /**
+     * @param registry the registry to set
+     */
+    public void setRegistry(StudioConfigRegistry registry) {
+        this.registry = registry;
     }
 
 }

--- a/shared/beans/src/main/java/io/apicurio/studio/shared/beans/StudioConfigRegistry.java
+++ b/shared/beans/src/main/java/io/apicurio/studio/shared/beans/StudioConfigRegistry.java
@@ -21,13 +21,13 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 /**
- * @author eric.wittmann@gmail.com
+ * @author c.desc2@gmail.com
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(Include.NON_NULL)
 public class StudioConfigRegistry {
 
-    private String url;
+    private String uiUrl;
 
     /**
      * Constructor.
@@ -38,15 +38,15 @@ public class StudioConfigRegistry {
     /**
      * @return the url
      */
-    public String getUrl() {
-        return url;
+    public String getUiUrl() {
+        return uiUrl;
     }
 
     /**
-     * @param url the url to set
+     * @param uiUrl the url to set
      */
-    public void setUrl(String url) {
-        this.url = url;
+    public void setUiUrl(String uiUrl) {
+        this.uiUrl = uiUrl;
     }
 
 }

--- a/shared/beans/src/main/java/io/apicurio/studio/shared/beans/StudioConfigRegistry.java
+++ b/shared/beans/src/main/java/io/apicurio/studio/shared/beans/StudioConfigRegistry.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.apicurio.studio.shared.beans;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+/**
+ * @author eric.wittmann@gmail.com
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(Include.NON_NULL)
+public class StudioConfigRegistry {
+
+    private String url;
+
+    /**
+     * Constructor.
+     */
+    public StudioConfigRegistry() {
+    }
+
+    /**
+     * @return the url
+     */
+    public String getUrl() {
+        return url;
+    }
+
+    /**
+     * @param url the url to set
+     */
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+}

--- a/shared/config/src/main/java/io/apicurio/studio/shared/config/Configuration.java
+++ b/shared/config/src/main/java/io/apicurio/studio/shared/config/Configuration.java
@@ -35,9 +35,6 @@ public abstract class Configuration {
     private static final String KC_AUTH_REALM_ENV = "APICURIO_KC_AUTH_REALM";
     private static final String KC_AUTH_REALM_SYSPROP = "apicurio.kc.auth.realm";
 
-    private static final String REGISTRY_URL_ENV = "APICURIO_REGISTRY_URL";
-    private static final String REGISTRY_URL_SYSPROP = "apicurio.registry.url";
-
     /**
      * @return the configured Keycloak auth URL
      */
@@ -50,13 +47,6 @@ public abstract class Configuration {
      */
     public String getKeycloakRealm() {
         return getConfigurationProperty(KC_AUTH_REALM_ENV, KC_AUTH_REALM_SYSPROP, "apicurio");
-    }
-
-    /**
-     * @return the URL of the Apicurio Registry Instance.
-     */
-    public String getRegistryUrl() {
-        return getConfigurationProperty(REGISTRY_URL_ENV, REGISTRY_URL_SYSPROP, null);
     }
 
     /**

--- a/shared/config/src/main/java/io/apicurio/studio/shared/config/Configuration.java
+++ b/shared/config/src/main/java/io/apicurio/studio/shared/config/Configuration.java
@@ -36,7 +36,7 @@ public abstract class Configuration {
     private static final String KC_AUTH_REALM_SYSPROP = "apicurio.kc.auth.realm";
 
     private static final String REGISTRY_URL_ENV = "APICURIO_REGISTRY_URL";
-    private static final String REGISTRY_URL_SYSPROP = "apicurio-registry.url";
+    private static final String REGISTRY_URL_SYSPROP = "apicurio.registry.url";
 
     /**
      * @return the configured Keycloak auth URL
@@ -53,7 +53,7 @@ public abstract class Configuration {
     }
 
     /**
-     * Returns the URL of the Apicurio Registry Instance.
+     * @return the URL of the Apicurio Registry Instance.
      */
     public String getRegistryUrl() {
         return getConfigurationProperty(REGISTRY_URL_ENV, REGISTRY_URL_SYSPROP, null);

--- a/shared/config/src/main/java/io/apicurio/studio/shared/config/Configuration.java
+++ b/shared/config/src/main/java/io/apicurio/studio/shared/config/Configuration.java
@@ -35,6 +35,9 @@ public abstract class Configuration {
     private static final String KC_AUTH_REALM_ENV = "APICURIO_KC_AUTH_REALM";
     private static final String KC_AUTH_REALM_SYSPROP = "apicurio.kc.auth.realm";
 
+    private static final String REGISTRY_URL_ENV = "APICURIO_REGISTRY_URL";
+    private static final String REGISTRY_URL_SYSPROP = "apicurio-registry.url";
+
     /**
      * @return the configured Keycloak auth URL
      */
@@ -47,6 +50,13 @@ public abstract class Configuration {
      */
     public String getKeycloakRealm() {
         return getConfigurationProperty(KC_AUTH_REALM_ENV, KC_AUTH_REALM_SYSPROP, "apicurio");
+    }
+
+    /**
+     * Returns the URL of the Apicurio Registry Instance.
+     */
+    public String getRegistryUrl() {
+        return getConfigurationProperty(REGISTRY_URL_ENV, REGISTRY_URL_SYSPROP, null);
     }
 
     /**


### PR DESCRIPTION
Hi @EricWittmann, 

As exposed in #1370, I'm working on the possibility to use the registry as a component source, with the idea that we will normalize our openapi/asyncapi specifications by externalizing data types and have them being referenced at an immutable revision.

I'm sending you this first draft so we can discuss the implementation and ways it could be enhanced.

As you'll see I tried to fit the overall style and architecture of the project while laying ground for the backend to act as a proxy if the registry needs to be protected from the users.

I edited the import-component-wizard in a way it joins the results from the 'designs' and 'registry' endpoints in the same list and visits all resources when needed (only for ASYNCAPI, OPENAPI and JSON artifact types atm). The selected components are then added as $ref to the latest published component version.

![image](https://user-images.githubusercontent.com/17125930/105355861-fb399400-5bf2-11eb-90d5-15934c381041.png)

I left some to-do tasks in the front end as I know very little of typescript and nothing of angular so I'd need someone's help on this part.

I also have performance concerns with the wizard fetching the entire registry inventory (does that happen with all APIs if shareWithEveryone is enabled?) but adding another wizard with search functionalities is over what I can do with angular.

If you want to run it you just have to add an APICURIO_REGISTRY_URL prop (from http to port number) to the api and ui modules.