### PR TITLE
fix: Improvements and fixes to helm chart

### DIFF
--- a/distro/helm/templates/NOTES.txt
+++ b/distro/helm/templates/NOTES.txt
@@ -7,7 +7,7 @@ To learn more about the release, try:
   $ helm status {{ .Release.Name }}
   $ helm get {{ .Release.Name }}
 
-Apicurio is available at {{ .Values.ui.hub.api.url }}
+Apicurio is available at https://{{ .Values.ui.hostname }}
 
 Keycloak that is defined is available on {{ .Values.keycloak.url }}
 {{- if .Values.ui.feature.microcks }}

--- a/distro/helm/templates/apicurio-studio-api-deployment.yaml
+++ b/distro/helm/templates/apicurio-studio-api-deployment.yaml
@@ -67,8 +67,18 @@ spec:
           imagePullPolicy: {{ .Values.api.imagePullPolicy }}
           ports:
             - containerPort: 8080
+          {{- if .Values.api.extraVolumes }}
+          volumeMounts:
+            {{- range $volume := .Values.api.extraVolumes }}
+            - mountPath: {{ $volume.mountPath | quote }}
+              name: {{ $volume.name | quote }}
+            {{- end }}
+          {{- end }}
       restartPolicy: Always
+      {{- if .Values.api.extraVolumes }}
       volumes:
-        - name: apicurio-secret
-          secret:
-            secretName: apicurio-secret
+        {{- range $volume := .Values.api.extraVolumes }}
+        - name: {{ $volume.name | quote }}
+          {{- $volume.volume | toYaml | nindent 10 }}
+        {{- end }}
+      {{- end }}

--- a/distro/helm/templates/apicurio-studio-db-deployment.yaml
+++ b/distro/helm/templates/apicurio-studio-db-deployment.yaml
@@ -17,10 +17,12 @@ spec:
         module: {{ .Values.database.name }}
     spec:
       containers:
-        - args:
+        - name: {{ .Values.database.name }}
+          args:
             - --default-authentication-plugin=mysql_native_password
             - --character-set-server=utf8mb4
             - --collation-server=utf8mb4_unicode_ci
+            - --ignore-db-dir=lost+found
           env:
             - name: MYSQL_DATABASE
               value: {{ .Values.database.schema }}
@@ -41,15 +43,21 @@ spec:
                   key: db-user
           image: {{ .Values.database.image }}
           imagePullPolicy: {{ .Values.database.imagePullPolicy }}
-          name: {{ .Values.database.name }}
           volumeMounts:
             - mountPath: /var/lib/mysql
               name: mysql-apicurio
+            {{- range $volume := .Values.database.extraVolumes }}
+            - mountPath: {{ $volume.mountPath | quote }}
+              name: {{ $volume.name | quote }}
+            {{- end }}
       restartPolicy: Always
       volumes:
         - name: mysql-apicurio
           persistentVolumeClaim:
             claimName: apicuriodata
-        - name: apicurio-secret
-          secret:
-            secretName: apicurio-secret
+        {{- range $volume := .Values.database.extraVolumes }}
+        - name: {{ $volume.name | quote }}
+          {{- $volume.volume | toYaml | nindent 10 }}
+        {{- end }}
+      securityContext:
+        fsGroup: 999

--- a/distro/helm/templates/apicurio-studio-ingresses.yaml
+++ b/distro/helm/templates/apicurio-studio-ingresses.yaml
@@ -9,7 +9,7 @@ metadata:
     module: {{ .Values.api.name }}
 spec:
   rules:
-    - host: apicurio
+    - host: {{ .Values.ui.hostname }}
       http:
         paths:
           - backend:
@@ -27,7 +27,7 @@ metadata:
     module: {{ .Values.ui.name }}
 spec:
   rules:
-    - host: apicurio
+    - host: {{ .Values.ui.hostname }}
       http:
         paths:
           - backend:
@@ -48,14 +48,15 @@ metadata:
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
   labels:
     module: {{ .Values.ws.name }}
 spec:
   rules:
-    - host: apicurio
+    - host: {{ .Values.ui.hostname }}
       http:
         paths:
           - backend:
               serviceName: {{ .Values.ws.name }}
               servicePort: {{ .Values.ws.port }}
-            path: /ws
+            path: /ws/?(.*)

--- a/distro/helm/templates/apicurio-studio-ui-deployment.yaml
+++ b/distro/helm/templates/apicurio-studio-ui-deployment.yaml
@@ -38,9 +38,9 @@ spec:
           - name: APICURIO_UI_LOGOUT_REDIRECT_URI
             value: {{ .Values.ui.logout.redirect.uri }}
           - name: APICURIO_UI_HUB_API_URL
-            value: {{ .Values.ui.hub.api.url }}
+            value: {{ .Values.ui.hub.api.url | default (print "https://" .Values.ui.hostname "/studio-api")  }}
           - name: APICURIO_UI_EDITING_URL
-            value: {{ .Values.ui.editing.url }}
+            value: {{ .Values.ui.editing.url | default (print "wss://" .Values.ui.hostname "/ws")  }}
           - name: JAVA_TOOL_OPTIONS
             value: {{ .Values.ui.jvmArgs }}
           - name: APICURIO_MICROCKS_API_URL
@@ -57,4 +57,18 @@ spec:
           name: {{ .Values.ui.name }}
           ports:
             - containerPort: 8080
+          {{- if .Values.ui.extraVolumes }}
+          volumeMounts:
+            {{- range $volume := .Values.ui.extraVolumes }}
+            - mountPath: {{ $volume.mountPath | quote }}
+              name: {{ $volume.name | quote }}
+            {{- end }}
+          {{- end }}
       restartPolicy: Always
+      {{- if .Values.ui.extraVolumes }}
+      volumes:
+        {{- range $volume := .Values.ui.extraVolumes }}
+        - name: {{ $volume.name | quote }}
+          {{- $volume.volume | toYaml | nindent 10 }}
+        {{- end }}
+      {{- end }}

--- a/distro/helm/templates/apicurio-studio-ws-deployment.yaml
+++ b/distro/helm/templates/apicurio-studio-ws-deployment.yaml
@@ -21,7 +21,7 @@ spec:
             value: debug
           {{- end }}
           - name: APICURIO_DB_CONNECTION_URL
-            value: {{ .Values.keycloak.url }}
+            value: {{ .Values.database.url }}
           - name: APICURIO_DB_DRIVER_NAME
             value: {{ .Values.database.driver }}
           - name: APICURIO_DB_INITIALIZE
@@ -47,4 +47,18 @@ spec:
           name: {{ .Values.ws.name }}
           ports:
             - containerPort: 8080
+          {{- if .Values.ws.extraVolumes }}
+          volumeMounts:
+            {{- range $volume := .Values.ws.extraVolumes }}
+            - mountPath: {{ $volume.mountPath | quote }}
+              name: {{ $volume.name | quote }}
+            {{- end }}
+          {{- end }}
       restartPolicy: Always
+      {{- if .Values.ws.extraVolumes }}
+      volumes:
+        {{- range $volume := .Values.ws.extraVolumes }}
+        - name: {{ $volume.name | quote }}
+          {{- $volume.volume | toYaml | nindent 10 }}
+        {{- end }}
+      {{- end }}

--- a/distro/helm/values.yaml
+++ b/distro/helm/values.yaml
@@ -4,6 +4,7 @@ api:
   jvmArgs: -Djava.net.preferIPv4Stack=true
   port: 8091
   imagePullPolicy: IfNotPresent
+  extraVolumes: []
 
 ui:
   name: apicurio-studio-ui
@@ -11,16 +12,18 @@ ui:
   jvmArgs: -Djava.net.preferIPv4Stack=true
   port: 8093
   imagePullPolicy: IfNotPresent
+  hostname: APICURIO_URL
+  extraVolumes: []
   logout:
     redirect:
       uri: "/"
   hub:
     api:
       # url to hub api
-      url: http://APICURIO_URL/studio-api
+      url: null
   editing:
     # url to editing
-    url: ws://APICURIO_URL/ws
+    url: null
   feature:
     microcks: false
 
@@ -30,6 +33,7 @@ ws:
   jvmArgs: -Djava.net.preferIPv4Stack=true
   port: 8092
   imagePullPolicy: IfNotPresent
+  extraVolumes: []
 
 database:
   name: apicurio-studio-db
@@ -45,6 +49,7 @@ database:
   password: apicuriodb
   rootPassword: apicuriodb
   user: apicuriodb
+  extraVolumes: []
 
 uiFeatureShareForEveryone: true
 loggingEnabled: false


### PR DESCRIPTION
This pull request represents the changes I had to make to the helm chart to get it working on our cluster.

So I'm making this PR to the upstream in the hopes others find it useful.

(After getting it working, I took all specific values and moved them into the values-yaml so the chart is more generic.)

Changes I did:
- Add `--ignore-db-dir=lost+found` to the mysql arguments, because some persistent volumes come with a lost+found directory
- Add `securityContext: fsGroup: 999` to the mysql deployment because otherwise mysql doesn't have write permissions on its storage volume
- Enable the option of adding extra volumemounts to pods (for us this was needed to mount the public-rootca of our company proxy)
- Change the ingress spec to be able to pass the hostname it's running on from the values (and use that hostname to point to the api and ws endpoints)
- Fixed a bug in the ws deployment where the database-connection was pointing to keycloak (a typo I guess)
