### PR TITLE
Fix microcks docker compose distro realm redirect uri

### DIFF
--- a/distro/docker-compose/config/keycloak/microcks-realm.json.template
+++ b/distro/docker-compose/config/keycloak/microcks-realm.json.template
@@ -109,7 +109,7 @@
         "+"
       ],
       "redirectUris": [
-        "https://$HOST:8900/*"
+        "http://$HOST:8900/*"
       ],
       "fullScopeAllowed": false
     },


### PR DESCRIPTION
Since the docker-compose distro comes without https support having this as a valid redirect uri makes no sense.