### PR TITLE
Fix command used in AsyncAPI deleteChannel: should be createDeleteChannelCommand

### DIFF
--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/aaimaster.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/aaimaster.component.ts
@@ -335,7 +335,7 @@ export class AsyncApiEditorMasterComponent extends AbstractBaseComponent {
      */
     public deleteChannel(): void {
         let channelItem: AaiChannelItem = this.contextMenuSelection.resolve(this.document) as AaiChannelItem;
-        let command: ICommand = CommandFactory.createDeletePathCommand(channelItem.getName());
+        let command: ICommand = CommandFactory.createDeleteChannelCommand(channelItem.getName());
         this.commandService.emit(command);
         this.closeContextMenu();
     }


### PR DESCRIPTION
Hello, 

When deleting a channel from an AsyncAPI document, a DeletePathCommand is stacked in storage and causes errors on application (can't cast AaiDocument to OasDocument).

This PR changes the created command to DeleteChannelCommand.

--
The renameChannel uses a wrong command too but I think the modal is inactive and no fitting command exists in data-models yet.