### PR TITLE
Fix a condition for list all user Gitlab projects

### DIFF
--- a/back-end/hub-api/src/main/java/io/apicurio/hub/api/gitlab/GitLabSourceConnector.java
+++ b/back-end/hub-api/src/main/java/io/apicurio/hub/api/gitlab/GitLabSourceConnector.java
@@ -404,7 +404,7 @@ public class GitLabSourceConnector extends AbstractSourceConnector implements IG
                 }
             }
             
-            if (group != null && group.equalsIgnoreCase(gitLabUsername)) {
+            if (group != null && group.equalsIgnoreCase(gitLabUserId)) {
                 // List all user projects
                 //////////////////////////////
                 Endpoint endpoint = pagedEndpoint("/api/v4/users/:user_id/projects", 1, DEFAULT_PAGE_SIZE).bind("user_id", gitLabUserId);


### PR DESCRIPTION
Fix #1447 
The API for searching for groups was being used when the group did not exist in the linked GitLab, resulting in the project not being displayed.