### PR TITLE
add java 11 in dockerfile because UnsupportedClassVersionError

### DIFF
--- a/platforms/thorntail/api/Dockerfile
+++ b/platforms/thorntail/api/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:7
 LABEL authors="Eric Wittmann <eric.wittmann@redhat.com>"
 ENV RELEASE_PATH target/apicurio-studio-api-thorntail.jar
 RUN yum install -y \
-    java-1.8.0-openjdk-headless \
+    java-11-openjdk-headless \
   && yum clean all
 
 WORKDIR /opt/apicurio

--- a/platforms/thorntail/ui/Dockerfile
+++ b/platforms/thorntail/ui/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:7
 LABEL authors="Eric Wittmann <eric.wittmann@redhat.com>"
 ENV RELEASE_PATH target/apicurio-studio-ui-thorntail.jar
 RUN yum install -y \
-    java-1.8.0-openjdk-headless \
+    java-11-openjdk-headless \
   && yum clean all
 
 WORKDIR /opt/apicurio

--- a/platforms/thorntail/ws/Dockerfile
+++ b/platforms/thorntail/ws/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:7
 LABEL authors="Eric Wittmann <eric.wittmann@redhat.com>"
 ENV RELEASE_PATH target/apicurio-studio-ws-thorntail.jar
 RUN yum install -y \
-    java-1.8.0-openjdk-headless \
+    java-11-openjdk-headless \
   && yum clean all
 
 WORKDIR /opt/apicurio


### PR DESCRIPTION
I had the following problem :

```
Caused by: java.lang.UnsupportedClassVersionError: Failed to link io/apicurio/studio/fe/servlet/servlets/AngularServlet 
(Module "deployment.apicurio-studio-ui.war" from Service Module Loader): 
io/apicurio/studio/fe/servlet/servlets/AngularServlet has been compiled by a more recent version of the 
Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
```

We can see that the release has been switched to Java 11 (see verify.yaml)
 
So in the thorntail images we need java 11
https://github.com/Apicurio/apicurio-studio/blob/master/.github/workflows/release.yaml#L110 
the image used in release.yaml is platforms/thorntail