### PR TITLE
Fix missing // in default studio.keycloak.url

### DIFF
--- a/platforms/quarkus/api/src/main/resources/application.properties
+++ b/platforms/quarkus/api/src/main/resources/application.properties
@@ -22,7 +22,7 @@
 quarkus.http.cors=true
 
 
-studio.keycloak.url=${APICURIO_KC_AUTH_URL:http:localhost:8090}
+studio.keycloak.url=${APICURIO_KC_AUTH_URL:http://localhost:8090}
 studio.keycloak.realm=${APICURIO_KC_REALM:apicurio}
 
 quarkus.oidc.application-type=service

--- a/platforms/quarkus/ui/src/main/resources/application.properties
+++ b/platforms/quarkus/ui/src/main/resources/application.properties
@@ -15,7 +15,7 @@
 
 quarkus.http.cors=true
 
-studio.keycloak.url=${APICURIO_KC_AUTH_URL:http:localhost:8090}
+studio.keycloak.url=${APICURIO_KC_AUTH_URL:http://localhost:8090}
 studio.keycloak.realm=${APICURIO_KC_REALM:apicurio}
 
 quarkus.oidc.application-type=web-app


### PR DESCRIPTION
Hello, 

We're using the platforms/quarkus package to test locally (eclipse + wildfly + jboss plugins were a bit too much for us) and this lil miss caused us some errors since quarkus failed initializing the default tenant and only logs the error as debug :)

---
If you're interested in the alternative dev mode it uses some javaenv+sed shenanigans but I pushed it there https://github.com/Apicurio/apicurio-studio/compare/master...DyspC:dev-mode