### PR TITLE
Use entrypoints instead of cmds in thorntail images

### DIFF
--- a/platforms/thorntail/api/Dockerfile
+++ b/platforms/thorntail/api/Dockerfile
@@ -8,10 +8,12 @@ RUN yum install -y \
 WORKDIR /opt/apicurio
 
 ADD ${RELEASE_PATH} /opt/apicurio
+ADD entrypoint.sh /opt/apicurio
 
 RUN groupadd -r apicurio -g 1001 \
     && useradd -u 1001 -r -g apicurio -d /opt/apicurio/ -s /sbin/nologin -c "Docker image user" apicurio \
     && chown -R apicurio:apicurio /opt/apicurio/ \
+    && chmod 554 /opt/apicurio/entrypoint.sh \
     && chgrp -R 0 /opt/apicurio && chmod -R g=u /opt/apicurio
 
 USER 1001
@@ -46,20 +48,4 @@ ENV APICURIO_BITBUCKET_API_URL=
 ENV APICURIO_UI_VALIDATION_CHANNELNAME_REGEXP='([^{}\/]*(\{[a-zA-Z_][0-9a-zA-Z_]*\})?)+'
 
 
-CMD java -jar /opt/apicurio/apicurio-studio-api-thorntail.jar \
-    -Xms${APICURIO_MIN_HEAP} \
-    -Xmx${APICURIO_MAX_HEAP} \
-    -Dthorntail.port.offset=${APICURIO_PORT_OFFSET} \
-    -Dthorntail.datasources.data-sources.ApicurioDS.driver-name=${APICURIO_DB_DRIVER_NAME} \
-    -Dthorntail.datasources.data-sources.ApicurioDS.connection-url=${APICURIO_DB_CONNECTION_URL} \
-    -Dthorntail.datasources.data-sources.ApicurioDS.user-name=${APICURIO_DB_USER_NAME} \
-    -Dthorntail.datasources.data-sources.ApicurioDS.password=${APICURIO_DB_PASSWORD} \
-    -Dthorntail.datasources.data-sources.ApicurioDS.valid-connection-checker-class-name=${APICURIO_DB_VALID_CONNECTION_CHECKER_CLASS_NAME} \
-    -Dthorntail.datasources.data-sources.ApicurioDS.validate-on-match=${APICURIO_DB_VALID_ON_MATCH} \
-    -Dthorntail.datasources.data-sources.ApicurioDS.background-validation=${APICURIO_DB_BACKGROUND_VALIDATION} \
-    -Dthorntail.datasources.data-sources.ApicurioDS.exception-sorter-class-name=${APICURIO_DB_EXCEPTION_SORTER_CLASS_NAME} \   
-    -Dapicurio.hub.storage.jdbc.init=${APICURIO_DB_INITIALIZE} \
-    -Dapicurio.hub.storage.jdbc.type=${APICURIO_DB_TYPE} \
-    -Dapicurio.kc.auth.rootUrl=${APICURIO_KC_AUTH_URL} \
-    -Dapicurio.kc.auth.realm=${APICURIO_KC_REALM} \
-    -Dthorntail.logging=${APICURIO_LOGGING_LEVEL}
+ENTRYPOINT ["/opt/apicurio/entrypoint.sh"]

--- a/platforms/thorntail/api/entrypoint.sh
+++ b/platforms/thorntail/api/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+java -jar /opt/apicurio/apicurio-studio-api-thorntail.jar \
+    -Xms${APICURIO_MIN_HEAP} \
+    -Xmx${APICURIO_MAX_HEAP} \
+    -Dthorntail.port.offset=${APICURIO_PORT_OFFSET} \
+    -Dthorntail.datasources.data-sources.ApicurioDS.driver-name=${APICURIO_DB_DRIVER_NAME} \
+    -Dthorntail.datasources.data-sources.ApicurioDS.connection-url=${APICURIO_DB_CONNECTION_URL} \
+    -Dthorntail.datasources.data-sources.ApicurioDS.user-name=${APICURIO_DB_USER_NAME} \
+    -Dthorntail.datasources.data-sources.ApicurioDS.password=${APICURIO_DB_PASSWORD} \
+    -Dthorntail.datasources.data-sources.ApicurioDS.valid-connection-checker-class-name=${APICURIO_DB_VALID_CONNECTION_CHECKER_CLASS_NAME} \
+    -Dthorntail.datasources.data-sources.ApicurioDS.validate-on-match=${APICURIO_DB_VALID_ON_MATCH} \
+    -Dthorntail.datasources.data-sources.ApicurioDS.background-validation=${APICURIO_DB_BACKGROUND_VALIDATION} \
+    -Dthorntail.datasources.data-sources.ApicurioDS.exception-sorter-class-name=${APICURIO_DB_EXCEPTION_SORTER_CLASS_NAME} \
+    -Dapicurio.hub.storage.jdbc.init=${APICURIO_DB_INITIALIZE} \
+    -Dapicurio.hub.storage.jdbc.type=${APICURIO_DB_TYPE} \
+    -Dapicurio.kc.auth.rootUrl=${APICURIO_KC_AUTH_URL} \
+    -Dapicurio.kc.auth.realm=${APICURIO_KC_REALM} \
+    -Dthorntail.logging=${APICURIO_LOGGING_LEVEL}

--- a/platforms/thorntail/ui/Dockerfile
+++ b/platforms/thorntail/ui/Dockerfile
@@ -8,10 +8,12 @@ RUN yum install -y \
 WORKDIR /opt/apicurio
 
 ADD ${RELEASE_PATH} /opt/apicurio
+ADD entrypoint.sh /opt/apicurio
 
 RUN groupadd -r apicurio -g 1001 \
     && useradd -u 1001 -r -g apicurio -d /opt/apicurio/ -s /sbin/nologin -c "Docker image user" apicurio \
     && chown -R apicurio:apicurio /opt/apicurio/ \
+    && chmod 554 /opt/apicurio/entrypoint.sh \
     && chgrp -R 0 /opt/apicurio && chmod -R g=u /opt/apicurio
 
 USER 1001
@@ -36,12 +38,4 @@ ENV APICURIO_UI_VALIDATION_CHANNELNAME_REGEXP='([^{}\/]*(\{[a-zA-Z_][0-9a-zA-Z_]
 
 
 
-CMD java -jar /opt/apicurio/apicurio-studio-ui-thorntail.jar \
-    -Xms${APICURIO_MIN_HEAP} \
-    -Xmx${APICURIO_MAX_HEAP} \
-    -Dthorntail.port.offset=${APICURIO_PORT_OFFSET} \
-    -Dapicurio-ui.hub-api.url=${APICURIO_UI_HUB_API_URL} \
-    -Dapicurio-ui.editing.url=${APICURIO_UI_EDITING_URL} \
-    -Dapicurio.kc.auth.rootUrl=${APICURIO_KC_AUTH_URL} \
-    -Dapicurio.kc.auth.realm=${APICURIO_KC_REALM} \
-    -Dthorntail.logging=${APICURIO_LOGGING_LEVEL}
+ENTRYPOINT ["/opt/apicurio/entrypoint.sh"]

--- a/platforms/thorntail/ui/entrypoint.sh
+++ b/platforms/thorntail/ui/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+java -jar /opt/apicurio/apicurio-studio-ui-thorntail.jar \
+    -Xms${APICURIO_MIN_HEAP} \
+    -Xmx${APICURIO_MAX_HEAP} \
+    -Dthorntail.port.offset=${APICURIO_PORT_OFFSET} \
+    -Dapicurio-ui.hub-api.url=${APICURIO_UI_HUB_API_URL} \
+    -Dapicurio-ui.editing.url=${APICURIO_UI_EDITING_URL} \
+    -Dapicurio.kc.auth.rootUrl=${APICURIO_KC_AUTH_URL} \
+    -Dapicurio.kc.auth.realm=${APICURIO_KC_REALM} \
+    -Dthorntail.logging=${APICURIO_LOGGING_LEVEL}

--- a/platforms/thorntail/ws/Dockerfile
+++ b/platforms/thorntail/ws/Dockerfile
@@ -8,10 +8,12 @@ RUN yum install -y \
 WORKDIR /opt/apicurio
 
 ADD ${RELEASE_PATH} /opt/apicurio
+ADD entrypoint.sh /opt/apicurio
 
 RUN groupadd -r apicurio -g 1001 \
     && useradd -u 1001 -r -g apicurio -d /opt/apicurio/ -s /sbin/nologin -c "Docker image user" apicurio \
     && chown -R apicurio:apicurio /opt/apicurio/ \
+    && chmod 554 /opt/apicurio/entrypoint.sh \
     && chgrp -R 0 /opt/apicurio && chmod -R g=u /opt/apicurio
 
 USER 1001
@@ -37,18 +39,4 @@ ENV APICURIO_MIN_HEAP=768m
 ENV APICURIO_MAX_HEAP=2048m
 
 
-CMD java -jar /opt/apicurio/apicurio-studio-ws-thorntail.jar \
-    -Xms${APICURIO_MIN_HEAP} \
-    -Xmx${APICURIO_MAX_HEAP} \
-    -Dthorntail.port.offset=${APICURIO_PORT_OFFSET} \
-    -Dthorntail.datasources.data-sources.ApicurioDS.driver-name=${APICURIO_DB_DRIVER_NAME} \
-    -Dthorntail.datasources.data-sources.ApicurioDS.connection-url=${APICURIO_DB_CONNECTION_URL} \
-    -Dthorntail.datasources.data-sources.ApicurioDS.user-name=${APICURIO_DB_USER_NAME} \
-    -Dthorntail.datasources.data-sources.ApicurioDS.password=${APICURIO_DB_PASSWORD} \
-    -Dthorntail.datasources.data-sources.ApicurioDS.valid-connection-checker-class-name=${APICURIO_DB_VALID_CONNECTION_CHECKER_CLASS_NAME} \
-    -Dthorntail.datasources.data-sources.ApicurioDS.validate-on-match=${APICURIO_DB_VALID_ON_MATCH} \
-    -Dthorntail.datasources.data-sources.ApicurioDS.background-validation=${APICURIO_DB_BACKGROUND_VALIDATION} \
-    -Dthorntail.datasources.data-sources.ApicurioDS.exception-sorter-class-name=${APICURIO_DB_EXCEPTION_SORTER_CLASS_NAME} \   
-    -Dapicurio.hub.storage.jdbc.init=${APICURIO_DB_INITIALIZE} \
-    -Dapicurio.hub.storage.jdbc.type=${APICURIO_DB_TYPE} \
-    -Dthorntail.logging=${APICURIO_LOGGING_LEVEL}
+ENTRYPOINT ["/opt/apicurio/entrypoint.sh"]

--- a/platforms/thorntail/ws/entrypoint.sh
+++ b/platforms/thorntail/ws/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+java -jar /opt/apicurio/apicurio-studio-ws-thorntail.jar \
+    -Xms${APICURIO_MIN_HEAP} \
+    -Xmx${APICURIO_MAX_HEAP} \
+    -Dthorntail.port.offset=${APICURIO_PORT_OFFSET} \
+    -Dthorntail.datasources.data-sources.ApicurioDS.driver-name=${APICURIO_DB_DRIVER_NAME} \
+    -Dthorntail.datasources.data-sources.ApicurioDS.connection-url=${APICURIO_DB_CONNECTION_URL} \
+    -Dthorntail.datasources.data-sources.ApicurioDS.user-name=${APICURIO_DB_USER_NAME} \
+    -Dthorntail.datasources.data-sources.ApicurioDS.password=${APICURIO_DB_PASSWORD} \
+    -Dthorntail.datasources.data-sources.ApicurioDS.valid-connection-checker-class-name=${APICURIO_DB_VALID_CONNECTION_CHECKER_CLASS_NAME} \
+    -Dthorntail.datasources.data-sources.ApicurioDS.validate-on-match=${APICURIO_DB_VALID_ON_MATCH} \
+    -Dthorntail.datasources.data-sources.ApicurioDS.background-validation=${APICURIO_DB_BACKGROUND_VALIDATION} \
+    -Dthorntail.datasources.data-sources.ApicurioDS.exception-sorter-class-name=${APICURIO_DB_EXCEPTION_SORTER_CLASS_NAME} \
+    -Dapicurio.hub.storage.jdbc.init=${APICURIO_DB_INITIALIZE} \
+    -Dapicurio.hub.storage.jdbc.type=${APICURIO_DB_TYPE} \
+    -Dthorntail.logging=${APICURIO_LOGGING_LEVEL}


### PR DESCRIPTION
Hello, 

I'm adding a corporate secret management layer to our studio deployment and I came into this issue where extending the image with an entrypoint erases the parent CMD

This change should allow image extension without having to maintain a copypaste of the CMD layer (eg. with another entrypoint ending with `exec /opt/apicurio/entrypoint.sh $@`)