### PR TITLE
Parameterize the schema-type-editor for aai message payloads/headers to only see data types

### DIFF
--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/channel/operation/headers-tab.component.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/channel/operation/headers-tab.component.html
@@ -16,6 +16,7 @@
                     <div class="mt-content" *ngIf="isEditingType()">
                         <div class="mt-type">
                             <schema-type-editor [document]="document()" [value]="model()" [isParameter]="false"
+                                                [dataTypesOnly]="true"
                                                 (onChange)="changeRefType($event)"></schema-type-editor>
                         </div>
                     </div>

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/channel/operation/payload-tab.component.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/channel/operation/payload-tab.component.html
@@ -20,6 +20,7 @@
                     <div class="mt-content" *ngIf="isEditingType()">
                         <div class="mt-type">
                             <schema-type-editor [document]="document()" [value]="model()" [isParameter]="false"
+                                                [dataTypesOnly]="true"
                                                 (onChange)="changeRefType($event)"></schema-type-editor>
                         </div>
                     </div>

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/schema-type-editor.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/shared/schema-type-editor.component.ts
@@ -71,6 +71,12 @@ export class SchemaTypeEditorComponent extends AbstractBaseComponent {
      * i.e. should the dropdown contain references to data type schemas?
      */
     @Input() isParameter: boolean = false;
+    
+    /**
+     * Should the component list "data type" definition only?
+     * i.e. should the primitive types and As/Of fields be masked?
+     */
+    @Input() dataTypesOnly: boolean = false;
 
     /**
      * Emit the value when it is updated
@@ -100,7 +106,9 @@ export class SchemaTypeEditorComponent extends AbstractBaseComponent {
      * Main options
      */
     public typeOptions(): DropDownOption[] {
-        let options: DropDownOption[] = [
+        let options: DropDownOption[] = [];
+        
+        let primitiveTypesOptions: DropDownOption[] = [
             new Value("Array", "array"),
             new Value("Enum", "enum"),
             DIVIDER,
@@ -111,12 +119,28 @@ export class SchemaTypeEditorComponent extends AbstractBaseComponent {
         ];
 
         /**
+         * Add primitive types to the dropdown menu
+         */
+        if (!this.dataTypesOnly) {
+            options.push(...primitiveTypesOptions);
+        }
+
+        /**
          * Add schema definitions to the dropdown menu
          */
-        options = [...options, ...this.getSchemaDefinitionsOptions()]
+        let schemaDefinitionsOptions = this.getSchemaDefinitionsOptions();
+        if (schemaDefinitionsOptions.length > 0) {
+            if (options.length > 0) {
+                options.push(DIVIDER);
+            }
+            options.push(...schemaDefinitionsOptions);
+        }
 
-        if(!this.isParameter && this.document.getDocumentType() === DocumentType.openapi2) {
-            options = [...options, DIVIDER, new Value("File", "file")]
+        if (!this.isParameter && !this.dataTypesOnly && this.document.getDocumentType() === DocumentType.openapi2) {
+            if (options.length > 0) {
+                options.push(DIVIDER);
+            }
+            options.push(new Value("File", "file"));
         }
 
         return options;
@@ -190,7 +214,6 @@ export class SchemaTypeEditorComponent extends AbstractBaseComponent {
         }
 
         if (defs.length > 0) {
-            options.push(DIVIDER);
             defs.forEach(def => {
                 let defName: string = def.getName();
                 options.push(new Value(defName, refPrefix + defName));


### PR DESCRIPTION
Hello, 

This PR is linked to (but does not depend on) https://github.com/Apicurio/apicurio-data-models/pull/324 and makes sure invalid ref values cannot be selected.

If data types exist in the document
![image](https://user-images.githubusercontent.com/17125930/132862965-ef7ee041-d1c7-462c-b457-46346497f395.png)

Or else 
![image](https://user-images.githubusercontent.com/17125930/132863054-baa979ea-8b09-43eb-bfd6-287987609642.png)

