### PR TITLE
Introduce user role injection from keycloak

### DIFF
--- a/back-end/hub-api/pom.xml
+++ b/back-end/hub-api/pom.xml
@@ -137,6 +137,11 @@
             </exclusions>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.json</groupId>
+            <artifactId>javax.json-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Keycloak -->
         <dependency>

--- a/back-end/hub-api/src/main/java/io/apicurio/hub/api/security/KeycloakAuthenticationFilter.java
+++ b/back-end/hub-api/src/main/java/io/apicurio/hub/api/security/KeycloakAuthenticationFilter.java
@@ -17,6 +17,8 @@
 package io.apicurio.hub.api.security;
 
 import java.io.IOException;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.servlet.Filter;
@@ -30,6 +32,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.keycloak.KeycloakSecurityContext;
 import org.keycloak.representations.AccessToken;
 
+import io.apicurio.studio.shared.beans.StudioRole;
 import io.apicurio.studio.shared.beans.User;
 
 /**
@@ -65,6 +68,10 @@ public class KeycloakAuthenticationFilter implements Filter {
                 user.setEmail(token.getEmail());
                 user.setLogin(token.getPreferredUsername());
                 user.setName(token.getName());
+                user.setRoles(token.getRealmAccess().getRoles().stream()
+                        .map(StudioRole::forName)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toUnmodifiableList()));
                 ((SecurityContext) security).setUser(user);
                 ((SecurityContext) security).setToken(session.getTokenString());
             }

--- a/back-end/hub-api/src/main/java/io/apicurio/hub/api/security/QuarkusAuthenticationFilter.java
+++ b/back-end/hub-api/src/main/java/io/apicurio/hub/api/security/QuarkusAuthenticationFilter.java
@@ -17,13 +17,18 @@
 package io.apicurio.hub.api.security;
 
 
+import io.apicurio.studio.shared.beans.StudioRole;
 import io.apicurio.studio.shared.beans.User;
 import io.smallrye.jwt.auth.principal.JWTCallerPrincipal;
 
 import javax.inject.Inject;
+import javax.json.JsonObject;
+import javax.json.JsonString;
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * This is a simple filter that extracts authentication information from the
@@ -59,6 +64,14 @@ public class QuarkusAuthenticationFilter implements Filter {
             user.setEmail(principal.getClaim("email"));
             user.setLogin(principal.getClaim("preferred_username"));
             user.setName(principal.getClaim("name"));
+            user.setRoles(
+                    principal.<JsonObject>getClaim("realm_access")
+                            .getJsonArray("roles").stream()
+                            .map(JsonString.class::cast)
+                            .map(JsonString::getString)
+                            .map(StudioRole::forName)
+                            .filter(Objects::nonNull)
+                            .collect(Collectors.toUnmodifiableList()));
             ((SecurityContext) security).setUser(user);
             ((SecurityContext) security).setToken(principal.getRawToken());
 

--- a/back-end/hub-api/src/test/java/io/apicurio/hub/api/rest/impl/DesignsResourceTest.java
+++ b/back-end/hub-api/src/test/java/io/apicurio/hub/api/rest/impl/DesignsResourceTest.java
@@ -48,6 +48,8 @@ import io.apicurio.hub.api.connectors.SourceConnectorFactory;
 import io.apicurio.hub.api.github.GitHubResourceResolver;
 import io.apicurio.hub.api.gitlab.GitLabResourceResolver;
 import io.apicurio.hub.api.rest.IDesignsResource;
+import io.apicurio.hub.core.auth.IAuthorizationService;
+import io.apicurio.hub.core.auth.impl.AuthorizationService;
 import io.apicurio.hub.core.beans.ApiContentType;
 import io.apicurio.hub.core.beans.ApiDesign;
 import io.apicurio.hub.core.beans.ApiDesignCollaborator;
@@ -92,6 +94,7 @@ public class DesignsResourceTest {
     private BitbucketResourceResolver bitbucketResolver;
     private MockMetrics metrics;
     private MockEventsService eventsService;
+    private IAuthorizationService authorizationService;
 
     @Before
     public void setUp() {
@@ -107,6 +110,7 @@ public class DesignsResourceTest {
         gitLabResolver = new GitLabResourceResolver();
         bitbucketResolver = new BitbucketResourceResolver();
         eventsService = new MockEventsService();
+        authorizationService = new AuthorizationService();
 
         sourceConnectorFactory = new SourceConnectorFactory();
         github = new MockGitHubService();
@@ -122,6 +126,9 @@ public class DesignsResourceTest {
         TestUtil.setPrivateField(bitbucketResolver, "config", config);
         bitbucketResolver.postConstruct();
 
+        TestUtil.setPrivateField(authorizationService, "config", config);
+        TestUtil.setPrivateField(authorizationService, "storage", storage);
+        
         TestUtil.setPrivateField(resource, "storage", storage);
         TestUtil.setPrivateField(resource, "sourceConnectorFactory", sourceConnectorFactory);
         TestUtil.setPrivateField(resource, "security", security);
@@ -132,6 +139,7 @@ public class DesignsResourceTest {
         TestUtil.setPrivateField(resource, "gitLabResolver", gitLabResolver);
         TestUtil.setPrivateField(resource, "bitbucketResolver", bitbucketResolver);
         TestUtil.setPrivateField(resource, "eventsService", eventsService);
+        TestUtil.setPrivateField(resource, "authorizationService", authorizationService);
     }
 
     @After

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/auth/IAuthorizationService.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/auth/IAuthorizationService.java
@@ -1,0 +1,50 @@
+package io.apicurio.hub.core.auth;
+
+import io.apicurio.hub.core.storage.StorageException;
+import io.apicurio.studio.shared.beans.User;
+
+/**
+ * Interface used to check the logged in user's authorization to execute a given action.
+ * @author c.desc2@gmail.com
+ */
+public interface IAuthorizationService {
+    
+    /**
+     * Checks whether the user has write access regardless of the design
+     * @param user the user
+     * @return if the user has write access
+     */
+    boolean hasWriteAllPermission(User user);
+
+    /**
+     * Checks whether the user has write permission on the design
+     * @param user the user
+     * @param designId the designId
+     * @return if the user has write access
+     */
+    boolean hasWritePermission(User user, String designId) throws StorageException;
+
+    /**
+     * Checks whether the user is collaborator or owner of the design
+     * @param user the user
+     * @param designId the designId
+     * @return if the user has write access
+     */
+    boolean hasPersonalWritePermission(User user, String designId) throws StorageException;
+
+    /**
+     * Checks whether the user has owner permission on the design
+     * @param user the user
+     * @param designId the designId
+     * @return if the user has owner permission
+     */
+    boolean hasOwnerPermission(User user, String designId) throws StorageException;
+
+    /**
+     * Checks whether the user is owner of the given design
+     * @param user the user
+     * @param designId the designId
+     * @return if the user is owner of the design
+     */
+    boolean hasPersonalOwnerPermission(User user, String designId) throws StorageException;
+}

--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/auth/impl/AuthorizationService.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/auth/impl/AuthorizationService.java
@@ -1,0 +1,63 @@
+package io.apicurio.hub.core.auth.impl;
+
+import io.apicurio.hub.core.auth.IAuthorizationService;
+import io.apicurio.hub.core.config.HubConfiguration;
+import io.apicurio.hub.core.storage.IStorage;
+import io.apicurio.hub.core.storage.StorageException;
+import io.apicurio.studio.shared.beans.User;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Default;
+import javax.inject.Inject;
+
+@ApplicationScoped
+@Default
+public class AuthorizationService implements IAuthorizationService {
+
+    @Inject
+    private HubConfiguration config;
+    @Inject
+    private IStorage storage;
+
+    /**
+     * @see IAuthorizationService#hasWriteAllPermission(User)
+     */
+    @Override
+    public boolean hasWriteAllPermission(User user) {
+        return config.isShareForEveryone();
+    }
+
+    /**
+     * @see IAuthorizationService#hasWritePermission(User, String) 
+     */
+    @Override
+    public boolean hasWritePermission(User user, String designId) throws StorageException {
+        return hasWriteAllPermission(user)
+                || hasPersonalWritePermission(user, designId);
+    }
+
+    /**
+     * @see IAuthorizationService#hasPersonalWritePermission(User, String)
+     */
+    @Override
+    public boolean hasPersonalWritePermission(User user, String designId) throws StorageException {
+        return this.storage.hasWritePermission(user.getLogin(), designId);
+    }
+
+    /**
+     * @see IAuthorizationService#hasOwnerPermission(User, String)
+     */
+    @Override
+    public boolean hasOwnerPermission(User user, String designId) throws StorageException {
+        return hasPersonalOwnerPermission(user, designId);
+    }
+
+    /**
+     * @see IAuthorizationService#hasPersonalOwnerPermission(User, String)
+     */
+    @Override
+    public boolean hasPersonalOwnerPermission(User user, String designId) throws StorageException {
+        return this.storage.hasOwnerPermission(user.getLogin(), designId);
+    }
+        
+}

--- a/front-end/servlet/pom.xml
+++ b/front-end/servlet/pom.xml
@@ -117,5 +117,10 @@
             </exclusions>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.json</groupId>
+            <artifactId>javax.json-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/front-end/servlet/src/main/java/io/apicurio/studio/fe/servlet/filters/KeycloakAuthenticationFilter.java
+++ b/front-end/servlet/src/main/java/io/apicurio/studio/fe/servlet/filters/KeycloakAuthenticationFilter.java
@@ -17,6 +17,8 @@
 package io.apicurio.studio.fe.servlet.filters;
 
 import java.io.IOException;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -30,6 +32,7 @@ import javax.servlet.http.HttpSession;
 import org.keycloak.KeycloakSecurityContext;
 import org.keycloak.representations.AccessToken;
 
+import io.apicurio.studio.shared.beans.StudioRole;
 import io.apicurio.studio.fe.servlet.config.RequestAttributeKeys;
 import io.apicurio.studio.shared.beans.StudioConfigAuthType;
 import io.apicurio.studio.shared.beans.StudioConfigAuth;
@@ -75,6 +78,10 @@ public class KeycloakAuthenticationFilter implements Filter {
                 user.setEmail(token.getEmail());
                 user.setLogin(token.getPreferredUsername());
                 user.setName(token.getName());
+                user.setRoles(token.getRealmAccess().getRoles().stream()
+                        .map(StudioRole::forName)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toUnmodifiableList()));
                 httpSession.setAttribute(RequestAttributeKeys.USER_KEY, user);
             }
         }

--- a/front-end/studio/src/app/models/apicurio-role.enum.ts
+++ b/front-end/studio/src/app/models/apicurio-role.enum.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2017 JBoss Inc
+ * Copyright 2021 Red Hat
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {ApicurioRole} from "./apicurio-role.enum";
 
+export class ApicurioRole {
 
-export class User {
-    login: string;
-    id: number;
-    name: string;
-    email: string;
-    avatar: string;
-    roles: ApicurioRole[];
-
-    constructor() {
-        this.login = "";
-        this.name = "";
-        this.email = "";
-        this.roles = [];
-    }
+    public static APICURIO_ADMIN: string = "APICURIO_ADMIN";
 
 }

--- a/front-end/studio/src/app/services/auth-keycloak.service.ts
+++ b/front-end/studio/src/app/services/auth-keycloak.service.ts
@@ -20,6 +20,7 @@ import {User} from "../models/user.model";
 import {ConfigService} from "./config.service";
 import {HttpClient} from "@angular/common/http";
 import {Topic} from "apicurio-ts-core";
+import {ApicurioRole} from "../models/apicurio-role.enum";
 
 /**
  * A version of the authentication service that uses keycloak.js to provide
@@ -50,6 +51,8 @@ export class KeycloakAuthenticationService extends IAuthenticationService {
         user.name = this.keycloak.tokenParsed.name;
         user.login = this.keycloak.tokenParsed.preferred_username;
         user.email = this.keycloak.tokenParsed.email;
+        user.roles = this.keycloak.tokenParsed.realm_access.roles
+            .filter(o => Object.values(ApicurioRole).includes(o));
 
         this._authenticated.send(true);
         this._user = user;

--- a/front-end/studio/src/app/services/auth-oidc.service.ts
+++ b/front-end/studio/src/app/services/auth-oidc.service.ts
@@ -21,6 +21,7 @@ import {ConfigService} from "./config.service";
 import {HttpClient, HttpResponse} from "@angular/common/http";
 import {Topic} from "apicurio-ts-core";
 import {HttpUtils} from "../util/common";
+import {ApicurioRole} from "../models/apicurio-role.enum";
 
 
 export class OIDCDirectGrantAccessToken {
@@ -144,6 +145,8 @@ export class OIDCDirectGrantAuthenticationService extends IAuthenticationService
         user.login = tokenData["preferred_username"];
         user.email = tokenData["email"];
         user.name = tokenData["name"];
+        user.roles = tokenData["realm_access"]["roles"]
+            .filter(o => Object.values(ApicurioRole).includes(o));
         return user;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,7 @@
         <version.javax.annotation>1.3.2</version.javax.annotation>
         <version.javax.enterprise>2.0</version.javax.enterprise>
         <version.javax.jms.jms-api>2.0.1</version.javax.jms.jms-api>
+        <version.javax.json>1.1.4</version.javax.json>
         <version.junit>4.13.2</version.junit>
         <version.org.apache.httpcomponents>4.5.13</version.org.apache.httpcomponents>
         <version.org.apache.httpcore>4.4.14</version.org.apache.httpcore>
@@ -377,6 +378,11 @@
                 <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-core</artifactId>
                 <version>${version.infinispan}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.json</groupId>
+                <artifactId>javax.json-api</artifactId>
+                <version>${version.javax.json}</version>
             </dependency>
 
             <!-- Gatling -->

--- a/shared/beans/src/main/java/io/apicurio/studio/shared/beans/StudioRole.java
+++ b/shared/beans/src/main/java/io/apicurio/studio/shared/beans/StudioRole.java
@@ -1,0 +1,33 @@
+package io.apicurio.studio.shared.beans;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public enum StudioRole {
+    APICURIO_ADMIN("apicurio_admin");
+
+    private static final Map<String, StudioRole> inverted;
+    static {
+        inverted = Arrays.stream(StudioRole.values())
+                .collect(Collectors.toMap(StudioRole::getName, Function.identity()));
+    }
+
+    private final String name;
+
+    StudioRole(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return the roleName
+     */
+    public String getName() {
+        return name;
+    }
+
+    public static StudioRole forName(String name) {
+        return inverted.get(name);
+    }
+}

--- a/shared/beans/src/main/java/io/apicurio/studio/shared/beans/User.java
+++ b/shared/beans/src/main/java/io/apicurio/studio/shared/beans/User.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
+import java.util.List;
+
 /**
  * @author eric.wittmann@gmail.com
  */
@@ -32,6 +34,7 @@ public class User {
     private String name;
     private String email;
     private String avatar;
+    private List<StudioRole> roles;
     
     /**
      * Constructor.
@@ -108,5 +111,27 @@ public class User {
     public void setLogin(String login) {
         this.login = login;
     }
-    
+
+    /**
+     * @return the roles
+     */
+    public List<StudioRole> getRoles() {
+        return roles;
+    }
+
+    /**
+     * @param roles the roles to set
+     */
+    public void setRoles(List<StudioRole> roles) {
+        this.roles = roles;
+    }
+
+    /**
+     * Checks the user roles for the desired role
+     * @param role the desired role
+     * @return
+     */
+    public boolean hasRole(StudioRole role) {
+        return this.roles != null && this.roles.contains(role);
+    }
 }


### PR DESCRIPTION
According to https://github.com/Apicurio/apicurio-studio/issues/1562#issuecomment-926855759, here is the first part that supports keycloak adding roles to the token and makes them accessible from the studio components.

I also added an AuthorizationService class to host auth decision depending on the user's ACLs / roles.

The role definition to update the realm of the apicurio-studio-auth image 
```json
{
  "id": "79f49397-7fb2-40b8-9e4c-bac26d756ae7",
  "name": "apicurio_admin",
  "description": "Admin role for users in Apicurio Studio",
  "composite": false,
  "clientRole": false,
  "containerId": "apicurio"
}
```

To get roles in the front end in dev mode, add them directly to the config.js file 
```
    user : {
        "login" : "[redacted]",
        "id" : 0,
        "name" : "[redacted]",
        "email" : "[redacted]",
        "roles" : [ "APICURIO_ADMIN" ]
    },
```

This is was originally part of a wider exploration to create an admin role with the ability to use an instance as if it had share with everyone enabled (in our use case a team that helps other people in the company design their APIs and manages API tooling) but I'm not satisfied with how hack-ish it is 
[Raw apicurio god mode role.txt](https://github.com/Apicurio/apicurio-studio/files/7236687/Raw.apicurio.god.mode.role.txt)
