### PR TITLE
Handle swagger reusable responses in response-tab

### DIFF
--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/path/operation/response-tab.component.css
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/path/operation/response-tab.component.css
@@ -48,3 +48,10 @@
 .response .response-examples a {
   cursor: pointer;
 }
+
+.response .response-ref em {
+  font-style: normal;
+}
+.response .response-ref em > a {
+  font-weight: bold;
+}

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/path/operation/response-tab.component.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/path/operation/response-tab.component.html
@@ -1,5 +1,5 @@
 <div class="response">
-    <div class="response-description">
+    <div class="response-description" *ngIf="!isRef()">
         <div class="form-label">Description</div>
         <div class="problem-flex">
             <validation-problem [model]="response" property="description"></validation-problem>
@@ -10,7 +10,7 @@
             </div>
         </div>
     </div>
-    <div class="response-type">
+    <div class="response-type" *ngIf="!isRef()">
         <div class="form-label">Response Type</div>
         <div class="problem-flex">
             <validation-problem [model]="response.schema"></validation-problem>
@@ -20,7 +20,7 @@
             </div>
         </div>
     </div>
-    <div class="response-examples">
+    <div class="response-examples" *ngIf="!isRef()">
         <div class="form-label">Examples</div>
         <div class="problem-flex">
             <validation-problem [model]="response.examples"></validation-problem>
@@ -53,6 +53,14 @@
                 <a (click)="addExampleDialog.open()">Add an example</a>
             </div>
         </div>
+    </div>
+
+    <div class="response-ref" *ngIf="isRef()">
+        <div class="form-label">Response Definition</div>
+        <validation-problem [model]="response" property="$ref"></validation-problem>
+        <span>This response references the </span>
+        <em><a (click)="navigateToDefinition()">{{ definitionName() }}</a></em>
+        <span> Response Definition.</span>
     </div>
 </div>
 <add-example-20-dialog #addExampleDialog (onAdd)="addExample($event)" [schema]="response.schema"></add-example-20-dialog>

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/path/operation/response-tab.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/path/operation/response-tab.component.ts
@@ -23,7 +23,7 @@ import {
     SimpleChanges,
     ViewEncapsulation
 } from "@angular/core";
-import {CommandFactory, ICommand, Library, Oas20Response, OasDocument, SimplifiedType} from "apicurio-data-models";
+import {CommandFactory, DocumentType, ICommand, Library, NodePath, Oas20Response, OasDocument, SimplifiedType} from "apicurio-data-models";
 import {CommandService} from "../../../../_services/command.service";
 import {DocumentService} from "../../../../_services/document.service";
 import {EditExample20Event} from "../../../dialogs/edit-example-20.component";
@@ -48,6 +48,40 @@ export class ResponseTabComponent extends AbstractBaseComponent {
     constructor(private changeDetectorRef: ChangeDetectorRef, private documentService: DocumentService,
                 private commandService: CommandService, private selectionService: SelectionService) {
         super(changeDetectorRef, documentService, selectionService);
+    }
+
+    isRef(): boolean {
+        return this.response.$ref !== null && this.response.$ref !== undefined;
+    }
+
+    responseDefRefPrefix(): string {
+        let prefix: string = "#/components/responses/";
+        if (this.response.ownerDocument().getDocumentType() === DocumentType.openapi2) {
+            prefix = "#/responses/";
+        }
+        return prefix;
+    }
+
+    responseDefPathPrefix(): string {
+        return this.responseDefRefPrefix().substr(1);
+    }
+
+    definitionName(): string {
+        if (this.isRef()) {
+            let prefix: string = this.responseDefRefPrefix();
+            let $ref: string = this.response.$ref;
+            if ($ref.startsWith(prefix)) {
+                return $ref.substr(prefix.length);
+            }
+            return this.response.$ref
+        }
+        return null;
+    }
+
+    navigateToDefinition(): void {
+        let path: NodePath = new NodePath(this.responseDefPathPrefix());
+        path.appendSegment(this.definitionName(), true);
+        this.selectionService.select(path.toString());
     }
 
     protected onDocumentChange(): void {


### PR DESCRIPTION
Hi,

This fixes an inconsistency between OAS3 and swagger (the swagger editor allowed picking reusable responses but they weren't rendered in design mode)