### PR TITLE
Fix templates and configs for Kubernetes and Helm

### DIFF
--- a/distro/helm/Chart.yaml
+++ b/distro/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: apicurio
-version: Beta 2.46
+version: 2.46.0-beta
 description: API design studio
 type: application
 keywords:

--- a/distro/helm/templates/apicurio-studio-ingresses.yaml
+++ b/distro/helm/templates/apicurio-studio-ingresses.yaml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: {{ .Values.api.name }}
   annotations:
@@ -13,12 +13,15 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: {{ .Values.api.name }}
-              servicePort: {{ .Values.api.port }}
+              service:
+                name: {{ .Values.api.name }}
+                port:
+                  number: {{ .Values.api.port }}
             path: /studio-api/?(.*)
+            pathType: Prefix
 ---
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: {{ .Values.ui.name }}
   annotations:
@@ -31,12 +34,15 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: {{ .Values.ui.name }}
-              servicePort: {{ .Values.ui.port }}
+              service:
+                name: {{ .Values.ui.name }}
+                port:
+                  number: {{ .Values.ui.port }}
             path: /
+            pathType: Prefix
 ---
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: {{ .Values.ws.name }}
   annotations:
@@ -57,6 +63,9 @@ spec:
       http:
         paths:
           - backend:
-              serviceName: {{ .Values.ws.name }}
-              servicePort: {{ .Values.ws.port }}
+              service:
+                name: {{ .Values.ws.name }}
+                port:
+                  number: {{ .Values.ws.port }}
             path: /ws/?(.*)
+            pathType: Prefix

--- a/distro/kubernetes/apicurio-studio-ingresses.yaml
+++ b/distro/kubernetes/apicurio-studio-ingresses.yaml
@@ -1,5 +1,5 @@
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: apicurio-studio-api
   annotations:
@@ -12,12 +12,15 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: "apicurio-studio-api"
-          servicePort: 8091
+          service:
+            name: "apicurio-studio-api"
+            port:
+              number: 8091
         path: /studio-api/?(.*)
+        pathType: Prefix
 ---
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: apicurio-studio-ui
   labels:
@@ -28,12 +31,15 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: "apicurio-studio-ui"
-          servicePort: 8093
+          service:
+            name: "apicurio-studio-ui"
+            port:
+              number: 8093
         path: /
+        pathType: Prefix
 ---
 kind: Ingress
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 metadata:
   name: apicurio-studio-ws
   annotations:
@@ -45,6 +51,9 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: "apicurio-studio-ws"
-          servicePort: 8092
+          service:
+            name: "apicurio-studio-ws"
+            port:
+              number: 8092
         path: /designs
+        pathType: Prefix

--- a/distro/kubernetes/apicurio-studio-ui-deployment.yaml
+++ b/distro/kubernetes/apicurio-studio-ui-deployment.yaml
@@ -67,7 +67,7 @@ spec:
         - name: JAVA_TOOL_OPTIONS
           value: -Djava.net.preferIPv4Stack=true
         - name: APICURIO_UI_VALIDATION_CHANNELNAME_REGEXP
-            value: '{([^\x00-\x20\x7f"\'%<>\\^`{|}]|%[0-9A-Fa-f]{2}|\{[+#./;?&=,!@|]?((\w|%[0-9A-Fa-f]{2})(\.?(\w|%[0-9A-Fa-f]{2}))*(:[1-9]\d{0,3}|\*)?)(,((\w|%[0-9A-Fa-f]{2})(\.?(\w|%[0-9A-Fa-f]{2}))*(:[1-9]\d{0,3}|\*)?))*\})*'
+          value: "{([^\x00-\x20\x7f\\\"'%<>\\^`{|}]|%[0-9A-Fa-f]{2}|\\{[+#./;?&=,!@|]?((\\w|%[0-9A-Fa-f]{2})(\\.?(\\w|%[0-9A-Fa-f]{2}))*(:[1-9]\\d{0,3}|\\*)?)(,((\\w|%[0-9A-Fa-f]{2})(\\.?(\\w|%[0-9A-Fa-f]{2}))*(:[1-9]\\d{0,3}|\\*)?))*\\})*"
         - name: APICURIO_MICROCKS_API_URL
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
I experienced compatibility issues when trying to deploy Apicurio to Kubernetes using Minikube so I decided to fix them. 

Perhaps you require these to be on an older version and need them to stay as they are, in which case feel free to close this.