### PR TITLE
Update H2 database

### DIFF
--- a/test/integration/arquillian/pom.xml
+++ b/test/integration/arquillian/pom.xml
@@ -30,7 +30,7 @@
         <artemis.config>${basedir}/src/test/resources/artemis/broker.xml</artemis.config>
         
         <!-- Use a specific version of H2 for compatibility with Wildfly -->
-        <h2.version>1.4.193</h2.version>
+        <h2.version>2.0.206</h2.version>
         <h2.install.dir>${project.build.directory}</h2.install.dir>
     </properties>
 


### PR DESCRIPTION
This fixes this security issue:
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42392.
More info here:
GHSA-h376-j262-vhq6