### PR TITLE
Adjustments to deploy Quarkus flavor with Operator

### DIFF
--- a/platforms/quarkus/api/src/main/resources/application.properties
+++ b/platforms/quarkus/api/src/main/resources/application.properties
@@ -22,11 +22,11 @@
 quarkus.http.cors=true
 
 
-studio.keycloak.url=${APICURIO_KC_AUTH_URL:http://localhost:8090}
+studio.keycloak.url=${APICURIO_KC_AUTH_URL:http://localhost:8090/auth}
 studio.keycloak.realm=${APICURIO_KC_REALM:apicurio}
 
 quarkus.oidc.application-type=service
-quarkus.oidc.auth-server-url=${studio.keycloak.url}/auth/realms/${studio.keycloak.realm}
+quarkus.oidc.auth-server-url=${studio.keycloak.url}/realms/${studio.keycloak.realm}
 quarkus.oidc.client-id=${APICURIO_KC_CLIENT_ID:apicurio-api}
 
 quarkus.oidc.connection-delay=PT60S

--- a/platforms/quarkus/ui/README.md
+++ b/platforms/quarkus/ui/README.md
@@ -37,7 +37,9 @@ For both profiles you need to provide connection configuration for a oidc server
  |OIDC Realm|`-Dstudio.keycloak.realm`|`APICURIO_KC_REALM`|
  |OIDC Client ID|`-Dquarkus.oidc.client-id`|`APICURIO_KC_CLIENT_ID`|
  
- 
+In `prod` profile, by default, the OIDC connector forces the `redirect_uri` to use `https://` URI - considering this component may be deployed behind a reverse proxy that handles the TLS termination.
+To disable this behavior, you may set the `APICURIO_OIDC_REDIRECT_HTTPS` environment variable to `false`.
+
 To see additional options, visit:
  - [OIDC Options](https://quarkus.io/guides/security-openid-connect) 
  

--- a/platforms/quarkus/ui/src/main/resources/application.properties
+++ b/platforms/quarkus/ui/src/main/resources/application.properties
@@ -13,13 +13,18 @@
 %prod.apicurio-ui.hub-api.url=${APICURIO_UI_HUB_API_URL:}
 %prod.apicurio-ui.validation.channelName.regexp=${APICURIO_UI_VALIDATION_CHANNELNAME_REGEXP:}
 
+# When in container accessed with http, the OIDC does not detect https termination
+# from the router/reverse proxy in front. We should force the redirection being https.
+%prod.quarkus.oidc.authentication.force-redirect-https-scheme=${APICURIO_OIDC_REDIRECT_HTTPS:true}
+%prod.quarkus.log.level=INFO
+
 quarkus.http.cors=true
 
-studio.keycloak.url=${APICURIO_KC_AUTH_URL:http://localhost:8090}
+studio.keycloak.url=${APICURIO_KC_AUTH_URL:http://localhost:8090/auth}
 studio.keycloak.realm=${APICURIO_KC_REALM:apicurio}
 
 quarkus.oidc.application-type=web-app
-quarkus.oidc.auth-server-url=${studio.keycloak.url}/auth/realms/${studio.keycloak.realm}
+quarkus.oidc.auth-server-url=${studio.keycloak.url}/realms/${studio.keycloak.realm}
 quarkus.oidc.client-id=${APICURIO_KC_CLIENT_ID:apicurio-studio}
 
 quarkus.oidc.connection-delay=PT60S

--- a/platforms/quarkus/ws/src/main/resources/application.properties
+++ b/platforms/quarkus/ws/src/main/resources/application.properties
@@ -20,6 +20,6 @@
 %prod.quarkus.datasource.jdbc.max-size=8
 %prod.quarkus.datasource.jdbc.min-size=2
 %prod.quarkus.log.level=INFO
-
+%prod.quarkus.http.port=8080
 
 quarkus.package.type=legacy-jar


### PR DESCRIPTION
Some adjustments to allow deployment of Quarkus flavor using Operator:
- Fix exposition port of ws component
- Force OIDC redirect_uri to be https when deployed behing an ingress controller that handles TLS
- Make Keycloak URL config the same that Wildfly falvor so that both can be deployed with Operator