### PR TITLE
Rename NPM package to '@apicurio/data-models'

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,8 +45,8 @@ jobs:
           mkdir studio
           cd studio
           git init
-          git config --global user.name "apicurio-ci"
-          git config --global user.email "eric.wittmann+apicurio-ci@gmail.com"
+          git config --global user.name "apicurio-ci[bot]"
+          git config --global user.email "apicurio-ci@users.noreply.github.com"
           git remote add origin "https://apicurio-ci:${{ secrets.ACCESS_TOKEN }}@github.com/$GITHUB_REPOSITORY.git"
           git fetch
           git checkout ${{ github.event.inputs.branch }}
@@ -57,8 +57,8 @@ jobs:
           mkdir website
           cd website
           git init
-          git config --global user.name "apicurio-ci"
-          git config --global user.email "apicurio.ci@gmail.com"
+          git config --global user.name "apicurio-ci[bot]"
+          git config --global user.email "apicurio-ci@users.noreply.github.com"
           git remote add origin "https://apicurio-ci:${{ secrets.ACCESS_TOKEN }}@github.com/Apicurio/apicurio.github.io.git"
           git fetch
           git checkout master

--- a/front-end/studio/README-npm.md
+++ b/front-end/studio/README-npm.md
@@ -67,7 +67,7 @@ the `package.json` file:
 
 ```json
 {
-  "name": "apicurio-design-studio",
+  "name": "@apicurio/studio",
   "version": "1.0.1",
   "description": "A web application to help design restful APIs.",
   "license": "Apache-2.0"

--- a/front-end/studio/package.json
+++ b/front-end/studio/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "apicurio-design-studio",
+  "name": "@apicurio/studio",
   "version": "0.2.53",
   "description": "A web application to help design restful APIs.",
   "author": "Eric Wittmann",


### PR DESCRIPTION
This PR moves the NPM package under the `@apicurio` organization. I also noticed some incorrect information in the README which I updated.

Additionally, 7fba69fb9dd2196c4d64b6d0ae50cb9bebe7fc53 hides the email address of our bot account. This should be more secure and leaves it less vulnerable to attacks and spam.
