### PR TITLE
#1894 Update jackson-databind to get missing annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <version.properties-maven-plugin>1.1.0</version.properties-maven-plugin>
 
         <!-- Dependency Versions -->
-        <version.com.fasterxml.jackson>2.12.5</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.13.2</version.com.fasterxml.jackson>
         <version.com.google.inject>4.1.0</version.com.google.inject>
         <version.com.graphql-java>17.3</version.com.graphql-java>
         <version.com.h2database>1.4.200</version.com.h2database>


### PR DESCRIPTION
> Fix for issue #1894 

Upgrading to `jackson-databind:2.13.2` fixes the class loading issue and does not bring regressions.