### PR TITLE
Use Temurin Distribution

### DIFF
--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -52,10 +52,10 @@ jobs:
           fi
 
       - name: Set up JDK 11
-        uses: AdoptOpenJDK/install-jdk@v1
+        uses: actions/setup-java@v3
         with:
-          version: '11'
-          architecture: x64
+          java-version: '11'
+          distribution: 'temurin'
 
       - name: Build Project
         run: cd studio && mvn clean install

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,10 +24,10 @@ jobs:
           node-version: 14
 
       - name: Set up JDK 11
-        uses: AdoptOpenJDK/install-jdk@v1
+        uses: actions/setup-java@v3
         with:
-          version: '11'
-          architecture: x64
+          java-version: '11'
+          distribution: 'temurin'
 
       - name: Set up Gren
         run: npm install github-release-notes -g

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -30,10 +30,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up JDK 11
-        uses: AdoptOpenJDK/install-jdk@v1
+        uses: actions/setup-java@v3
         with:
-          version: '11'
-          architecture: x64
+          java-version: '11'
+          distribution: 'temurin'
 
       - name: Build Project
         run: mvn clean install      
@@ -104,3 +104,5 @@ jobs:
          tags: |
            docker.io/apicurio/apicurio-studio-ui:latest-snapshot
            quay.io/apicurio/apicurio-studio-ui:latest-snapshot
+
+      


### PR DESCRIPTION
Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore.
It is highly recommended to migrate workflows from adopt to temurin to
keep receiving software and security updates.