### PR TITLE
Use PAT to create Github Release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -123,7 +123,7 @@ jobs:
         id: create_release
         uses: actions/create-release@latest
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         with:
           tag_name: ${{ github.event.inputs.release-version }} 
           release_name: ${{ github.event.inputs.release-version }}


### PR DESCRIPTION
Release created by the default token doesn't trigger the workflows based on the release event.