### PR TITLE
Add an option to generate a GH action workflow to generate clients from the spec

### DIFF
--- a/back-end/hub-api/src/main/java/io/apicurio/hub/api/rest/impl/DesignsResource.java
+++ b/back-end/hub-api/src/main/java/io/apicurio/hub/api/rest/impl/DesignsResource.java
@@ -1478,6 +1478,7 @@ public class DesignsResource implements IDesignsResource {
     private JaxRsProjectSettings toJaxRsSettings(CodegenProject project) {
         boolean codeOnly = "true".equals(project.getAttributes().get("codeOnly"));
         boolean reactive = "true".equals(project.getAttributes().get("reactive"));
+        boolean generateCliCi = "true".equals(project.getAttributes().get("generateCliCi"));
         String groupId = project.getAttributes().get("groupId");
         String artifactId = project.getAttributes().get("artifactId");
         String javaPackage = project.getAttributes().get("javaPackage");
@@ -1485,6 +1486,7 @@ public class DesignsResource implements IDesignsResource {
         JaxRsProjectSettings settings = new JaxRsProjectSettings();
         settings.codeOnly = codeOnly;
         settings.reactive = reactive;
+        settings.cliGenCI = generateCliCi;
         settings.groupId = groupId != null ? groupId : "org.example.api";
         settings.artifactId = artifactId != null ? artifactId : "generated-api";
         settings.javaPackage = javaPackage != null ? javaPackage : "org.example.api";

--- a/front-end/studio/src/app/pages/apis/{apiId}/_components/generate-project.wizard.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/_components/generate-project.wizard.html
@@ -116,6 +116,14 @@
                                                 <label for="jaxrs_reactive">Make the project Reactive (i.e. use CompletionStage&lt;T&gt; responses) </label>
                                             </div>
                                         </div>
+                                        <div class="form-group">
+                                            <div class="col-sm-2">&nbsp;</div>
+                                            <div class="col-sm-10">
+                                                <input name="generateCliCi" type="checkbox" id="jaxrs_generate_cli_ci" [(ngModel)]="model.projectData.generateCliCi">
+                                                <span>&nbsp;</span>
+                                                <label for="jaxrs_generate_cli_ci">Add a GH Action to generate and publish CLI code for multiple languages</label>
+                                            </div>
+                                        </div>
                                         <div class="form-group" *ngIf="!model.projectData.codeOnly">
                                             <label class="col-sm-2 control-label required" for="jaxrs_groupId">Group ID</label>
                                             <div class="col-sm-10">

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <!-- Other Apicurio Projects -->
         <version.apicurio-data-models>1.1.26</version.apicurio-data-models>
         <version.apicurio-registry>1.3.2.Final</version.apicurio-registry>
-        <version.apicurio-codegen>1.0.9.Final</version.apicurio-codegen>
+        <version.apicurio-codegen>1.0.11.Final</version.apicurio-codegen>
 
         <!-- Apache Artemis Version -->
         <version.apache-artemis>2.6.4</version.apache-artemis>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <!-- Other Apicurio Projects -->
         <version.apicurio-data-models>1.1.26</version.apicurio-data-models>
         <version.apicurio-registry>1.3.2.Final</version.apicurio-registry>
-        <version.apicurio-codegen>1.0.8.Final</version.apicurio-codegen>
+        <version.apicurio-codegen>1.0.9-SNAPSHOT</version.apicurio-codegen>
 
         <!-- Apache Artemis Version -->
         <version.apache-artemis>2.6.4</version.apache-artemis>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <!-- Other Apicurio Projects -->
         <version.apicurio-data-models>1.1.26</version.apicurio-data-models>
         <version.apicurio-registry>1.3.2.Final</version.apicurio-registry>
-        <version.apicurio-codegen>1.0.9-SNAPSHOT</version.apicurio-codegen>
+        <version.apicurio-codegen>1.0.9.Final</version.apicurio-codegen>
 
         <!-- Apache Artemis Version -->
         <version.apache-artemis>2.6.4</version.apache-artemis>


### PR DESCRIPTION
Creating as draft as it needs first:
https://github.com/Apicurio/apicurio-codegen/pull/38

The resulting "release" looks as follows:
https://github.com/andreaTP/openapi-cli-gen-ci-poc/releases/tag/0.0.3-SNAPSHOT

Each client `.zip` file contains the sources for the target language/framework as emitted by `openapi-generator`
