### PR TITLE
fix: data can be non-string which does not have trim()

### DIFF
--- a/front-end/studio/src/app/components/common/markdown.component.ts
+++ b/front-end/studio/src/app/components/common/markdown.component.ts
@@ -41,6 +41,6 @@ export class MarkdownComponent implements OnChanges {
     }
 
     public isEmpty(): boolean {
-        return this.data === null || this.data === undefined || this.data.trim().length === 0;
+        return this.data === null || this.data === undefined || (this.data.trim ? this.data.trim().length === 0 : true);
     }
 }


### PR DESCRIPTION
`isEmpty()` function breaks whenever data is a number. Data can be a number when an API definition is imported from JSON/YAML. I believe it can also be a boolean.

The change checks if data has a `trim` function, and runs it if so.

Example property in a schema that triggers the error:

```
        "properties": {
          "id": {
            "type": "integer",
            "format": "int64",
            "example": 10
          },
```