### PR TITLE
Fix too large message cause offline

### DIFF
--- a/platforms/quarkus/ws/src/main/resources/application.properties
+++ b/platforms/quarkus/ws/src/main/resources/application.properties
@@ -8,7 +8,7 @@
 %dev.quarkus.datasource.jdbc.max-size=8
 %dev.quarkus.datasource.jdbc.min-size=2
 %dev.quarkus.http.port=8092
-%dev.quarkus.websocket.max.frame.size=131072
+%dev.quarkus.websocket.max-frame-size=131072
 
 
 # === Prod profile, uses postgres as database
@@ -22,7 +22,7 @@
 %prod.quarkus.datasource.jdbc.min-size=2
 %prod.quarkus.log.level=INFO
 %prod.quarkus.http.port=8080
-%prod.quarkus.websocket.max.frame.size=2097152
+%prod.quarkus.websocket.max-frame-size=2097152
 
 
 # === Prod profile, mysql


### PR DESCRIPTION
Hello, 

In answer to issue #2082 : 
The correct spelling of the quarkus property websocket max frame size is : quarkus.websocket.max-frame-size

Official doc : 
![image](https://user-images.githubusercontent.com/118544135/223375556-45d12014-81a6-41f8-8610-9510a266f6f1.png)

Can you check this modification ? 
Happy if it helps :smile: 
