### PR TITLE
Add request body description title

### DIFF
--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/path/operation/requestBody-section.component.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/path/operation/requestBody-section.component.html
@@ -31,6 +31,9 @@
                 <strong>Not Recommended</strong>
                 <span>It is unusual and not recommended to define a request body for a <strong>GET</strong> operation.</span>
             </div>
+            <div class="request-body-content">
+                <div class="form-label">Description</div>
+            </div>
             <inline-markdown-editor [value]="bodyDescription()" noValueMessage="No request body description."
                                     labelClass="request-body-description api-item-description description"
                                     inputClass="api-description-editor api-item-description request-body-description api-item-description description"
@@ -59,6 +62,9 @@
                 <span class="pficon pficon-warning-triangle-o"></span>
                 <strong>Not Recommended</strong>
                 <span>It is unusual and not recommended to define a request body for a <strong>GET</strong> operation.</span>
+            </div>
+            <div class="request-body-content">
+                <div class="form-label">Description</div>
             </div>
             <inline-markdown-editor [value]="bodyDescription()" noValueMessage="No request body description."
                                     labelClass="request-body-description api-item-description description"


### PR DESCRIPTION
Hello, 

I realised that the request body doesn't have description title as you can see on this screenshot : 
![image](https://github.com/Apicurio/apicurio-studio/assets/118544135/ed2bff62-a320-409a-a405-d786c3295630)


This modification add the "Description" title on this section : 
![image](https://github.com/Apicurio/apicurio-studio/assets/118544135/d30c8ddb-fe81-49ff-afb5-bcd8f4a4143f)


