### PR TITLE
Use the same Keycloak Realm env

### DIFF
--- a/shared/config/src/main/java/io/apicurio/studio/shared/config/Configuration.java
+++ b/shared/config/src/main/java/io/apicurio/studio/shared/config/Configuration.java
@@ -32,7 +32,7 @@ public abstract class Configuration {
     private static final String KC_AUTH_URL_ENV = "APICURIO_KC_AUTH_URL";
     private static final String KC_AUTH_URL_SYSPROP = "apicurio.kc.auth.rootUrl";
 
-    private static final String KC_AUTH_REALM_ENV = "APICURIO_KC_AUTH_REALM";
+    private static final String KC_AUTH_REALM_ENV = "APICURIO_KC_REALM";
     private static final String KC_AUTH_REALM_SYSPROP = "apicurio.kc.auth.realm";
 
     /**


### PR DESCRIPTION
I'm using a custom Realm, following the documentation and in many places of the code, set up the `APICURIO_KC_REALM` env.

But some integrations, as the Github link account, still redirects the users to 'apicurio', the default realm, causing an error, because in my case we dont have the 'apicurio' realm.

Take a looking,  the env `APICURIO_KC_AUTH_REALM` still uses 'apicurio' as value, maybe an old code. 

Instead of the set-up the two env vars, my idea was to change the config to use the `APICURIO_KC_REALM`.

Maybe the props in this file an outdated too.