### PR TITLE
fix(mysql): increase websocket max frame size to handle full source editing

### DIFF
--- a/platforms/quarkus/ws/src/main/resources/application.properties
+++ b/platforms/quarkus/ws/src/main/resources/application.properties
@@ -34,5 +34,6 @@
 %mysql.quarkus.datasource.jdbc.max-size=8
 %mysql.quarkus.datasource.jdbc.min-size=2
 %mysql.quarkus.log.level=INFO
+%mysql.quarkus.websocket.max-frame-size=2097152
 
 quarkus.package.type=legacy-jar


### PR DESCRIPTION
- ensures users can edit the source of an api design and save it's contents over a websocket
- related to the fix introduced in https://github.com/Apicurio/apicurio-studio/commit/3f2a21360522ce4869f7f3d3c407b9eebd243fe8, but for mysql
- related to https://github.com/Apicurio/apicurio-studio/issues/1992