### PR TITLE
issue #441 and #460: Add the default value for simple types in the editor 

### DIFF
--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/definition/property-row.component.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/definition/property-row.component.html
@@ -91,6 +91,26 @@
                                                                (onChange)="setPattern($event)"></pf-inline-text-editor>
                                     </div>
                                 </div>
+
+                                <div class="property-default" *ngIf="isBooleanEligible()">
+                                    <checkbox-input [defaultValue]="getDefaultBoolean()" [name]="'readOnly'" label="Default true"
+                                                    id="default_" [baseNode]="item" nodePath="default_"
+                                                    (onChange)="setBoolean($event,'default_')"></checkbox-input>
+                                </div>
+                                <div class="property-default" *ngIf="isDefault_Eligible()">
+                                    <div class="property-label">
+                                        <label for="default">Default</label>
+                                    </div>
+                                    <div class="property-value">
+                                        <pf-inline-text-editor [value]="item.default_"
+                                                               noValueMessage="No default."
+                                                               id="default_"
+                                                               [baseNode]="item"
+                                                               nodePath="default_"
+                                                               (onChange)="setDefault($event)"></pf-inline-text-editor>
+                                    </div>
+                                </div>
+
                             </div>
 
                             <!-- Min/max tab content -->

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/definition/property-row.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/definition/property-row.component.ts
@@ -90,6 +90,13 @@ export class PropertyRowComponent extends AbstractRowComponent<Oas20PropertySche
         }
     }
 
+    public default_(): string{
+        return this.item.default_;
+    }
+
+    public getDefaultBoolean(): boolean{
+        return this.item.default_ === "true";
+    }
     public description(): string {
         return this.item.description
     }
@@ -212,6 +219,14 @@ export class PropertyRowComponent extends AbstractRowComponent<Oas20PropertySche
         return this.item.type === "string"
     }
 
+    public isDefault_Eligible(): boolean  {
+        return (this.item.type === "string" || this.item.type === "integer" || this.item.type === "float" || this.item.type=== "number" || this.item.type=== "double");
+    }
+
+    public isBooleanEligible(): boolean{
+        return this.item.type === "boolean";
+    }
+
     public isArrayEligible(): boolean  {
         return this.item.type === "array"
     }
@@ -263,6 +278,19 @@ export class PropertyRowComponent extends AbstractRowComponent<Oas20PropertySche
     public setPattern(pattern: string): void {
             let command: ICommand = CommandFactory.createChangePropertyCommand<string>(this.item, "pattern", pattern);
             this.commandService.emit(command);
+    }
+
+    public setDefault(val: string): void {
+        let command: ICommand = null
+        if (this.item.type === "string" ){
+            command = CommandFactory.createChangePropertyCommand<string>(this.item, "default_", String(val));
+
+        }
+        if( this.item.type === "integer" || this.item.type === "float" ||  this.item.type=== "number" || this.item.type=== "double"){
+            command = CommandFactory.createChangePropertyCommand<number>(this.item, "default_", Number(val));
+
+        }
+        this.commandService.emit(command);
     }
 
     public changeRequired(newValue: string): void {


### PR DESCRIPTION
Add into the editor the possibility to set the default value for the simple types (String, integer, boolean ...)