### PR TITLE
Corrected APICURIO_UI_VALIDATION_CHANNELNAME_REGEXP in .env.template

### DIFF
--- a/distro/docker-compose/.env.template
+++ b/distro/docker-compose/.env.template
@@ -39,7 +39,7 @@ APICURIO_UI_KC_CLIENT_ID=apicurio-studio
 APICURIO_UI_HUB_API_URL=http://localhost:8091
 APICURIO_UI_EDITING_URL=ws://localhost:8092
 APICURIO_UI_FEATURE_MICROCKS=true
-APICURIO_UI_VALIDATION_CHANNELNAME_REGEXP='([^\x00-\x20\x7f"'\''%<>\\^`{|}]|%[0-9A-Fa-f]{2}|\{[+#./;?&=,!@|]?((\w|%[0-9A-Fa-f]{2})(\.?(\w|%[0-9A-Fa-f]{2}))*(:[1-9]\d{0,3}|\*)?)(,((\w|%[0-9A-Fa-f]{2})(\.?(\w|%[0-9A-Fa-f]{2}))*(:[1-9]\d{0,3}|\*)?))*\})*'
+APICURIO_UI_VALIDATION_CHANNELNAME_REGEXP="([^\x00-\x20\x7f\"'%<>\\\\^`{|}]|%[0-9A-Fa-f]{2}|\{[+#./;?&=,!@|]?((\w|%[0-9A-Fa-f]{2})(\.?(\w|%[0-9A-Fa-f]{2}))*(:[1-9]\d{0,3}|\*)?)(,((\w|%[0-9A-Fa-f]{2})(\.?(\w|%[0-9A-Fa-f]{2}))*(:[1-9]\d{0,3}|\*)?))*\})*"
 
 
 APICURIO_SHARE_FOR_EVERYONE=false


### PR DESCRIPTION
Hi @carlesarnal ,

In the `.env.example ` file, I switched` '' `to` ""`, `"` to `\"`, and` \ `to` \\` so that it can generate a correct regular expression into `.env`.

This will close #2260 .

Thank you for reviewing it.