### PR TITLE
Keycloak login

### DIFF
--- a/distro/docker-compose/.env.template
+++ b/distro/docker-compose/.env.template
@@ -39,7 +39,7 @@ APICURIO_UI_KC_CLIENT_ID=apicurio-studio
 APICURIO_UI_HUB_API_URL=http://localhost:8091
 APICURIO_UI_EDITING_URL=ws://localhost:8092
 APICURIO_UI_FEATURE_MICROCKS=true
-APICURIO_UI_VALIDATION_CHANNELNAME_REGEXP='([^\x00-\x20\x7f"'\''%<>\\^`{|}]|%[0-9A-Fa-f]{2}|\{[+#./;?&=,!@|]?((\w|%[0-9A-Fa-f]{2})(\.?(\w|%[0-9A-Fa-f]{2}))*(:[1-9]\d{0,3}|\*)?)(,((\w|%[0-9A-Fa-f]{2})(\.?(\w|%[0-9A-Fa-f]{2}))*(:[1-9]\d{0,3}|\*)?))*\})*'
+APICURIO_UI_VALIDATION_CHANNELNAME_REGEXP="([^\x00-\x20\x7f\"'%<>\\\\^`{|}]|%[0-9A-Fa-f]{2}|\{[+#./;?&=,!@|]?((\w|%[0-9A-Fa-f]{2})(\.?(\w|%[0-9A-Fa-f]{2}))*(:[1-9]\d{0,3}|\*)?)(,((\w|%[0-9A-Fa-f]{2})(\.?(\w|%[0-9A-Fa-f]{2}))*(:[1-9]\d{0,3}|\*)?))*\})*"
 
 
 APICURIO_SHARE_FOR_EVERYONE=false

--- a/distro/docker-compose/docker-compose.apicurio.yml
+++ b/distro/docker-compose/docker-compose.apicurio.yml
@@ -100,5 +100,6 @@ services:
     volumes:
       - ./config/keycloak/apicurio-realm.json:/opt/keycloak/data/import/apicurio-realm.json
       - ./config/keycloak/microcks-realm.json:/opt/keycloak/data/import/microcks-realm.json
-    network_mode: host
+    ports:
+    - "8090:8080"
 


### PR DESCRIPTION
Hi @carlesarnal ,

In this PR, I use `ports: - "8090:8080"` instead of `network_mode: host` in `docker-compose.apicurio.yml`. Now the `localhost:8090` can be accessed and we can sign in Keycloak using the username and password in `.env`.

This will close #2262 .

Thank you for your review.