### PR TITLE
Corrected APICURIO_KC_AUTH_URL for OpenShift distro

### DIFF
--- a/distro/openshift/setup.sh
+++ b/distro/openshift/setup.sh
@@ -16,9 +16,9 @@ authurl=$(oc get route apicurio-studio-auth -o go-template --template='{{.spec.h
 
 #Set Openshift route values based on fetch
 
-oc set env dc/apicurio-studio-api APICURIO_KC_AUTH_URL=http://"$authurl"/auth/realms/apicurio
+oc set env dc/apicurio-studio-api APICURIO_KC_AUTH_URL=http://"$authurl"/auth
 
-oc set env dc/apicurio-studio-ui APICURIO_KC_AUTH_URL=http://"$authurl"/auth/realms/apicurio
+oc set env dc/apicurio-studio-ui APICURIO_KC_AUTH_URL=http://"$authurl"/auth
 oc set env dc/apicurio-studio-ui APICURIO_UI_HUB_API_URL=http://"$apiurl"
 oc set env dc/apicurio-studio-ui APICURIO_UI_EDITING_URL=ws://"$wsurl"
 


### PR DESCRIPTION
Hi @carlesarnal,

I have corrected the **APICURIO_KC_AUTH_URL** that was getting set in **setup.sh** for apicurio-studio-api and apicurio-studio-ui. This should solve the issue that we are facing with the OIDC server not being available. 

Please have a look and let me know if any changes are required.

This will close #2265.

Thank You