### PR TITLE
Add QUARKUS_HTTP_PORT for Keycloak server

### DIFF
--- a/distro/docker-compose/docker-compose.apicurio.yml
+++ b/distro/docker-compose/docker-compose.apicurio.yml
@@ -91,6 +91,8 @@ services:
   keycloak-server:
     image: quay.io/keycloak/keycloak:19.0.2
     environment:
+      QUARKUS_HTTP_PORT: 8090
+
       KEYCLOAK_ADMIN: ${KEYCLOAK_USER}
       KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_PASSWORD}
       KEYCLOAK_IMPORT: /microcks-keycloak-config/apicurio-realm.json,/microcks-keycloak-config/microcks-realm.json


### PR DESCRIPTION
Hi @carlesarnal,

I have added **QUARKUS_HTTP_PORT** for keycloak-server. While going through the README.md I realized the port for the Keycloak server is not assigned hence this might be causing the issue.

Please have a look and let me know if any changes are required.

This will close #2262 

Thank you