### PR TITLE
Modified templates' version

### DIFF
--- a/distro/openshift/apicurio-deployment-configs-template.yml
+++ b/distro/openshift/apicurio-deployment-configs-template.yml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: apicurio-studio-standalone

--- a/distro/openshift/apicurio-image-streams-template.yml
+++ b/distro/openshift/apicurio-image-streams-template.yml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: apicurio-studio-image-streams-template

--- a/distro/openshift/apicurio-routes-template.yml
+++ b/distro/openshift/apicurio-routes-template.yml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: apicurio-studio-standalone-template

--- a/distro/openshift/apicurio-secrets-template.yml
+++ b/distro/openshift/apicurio-secrets-template.yml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: apicurio-studio-secrets-template

--- a/distro/openshift/apicurio-services-template.yml
+++ b/distro/openshift/apicurio-services-template.yml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: apicurio-studio-services-template


### PR DESCRIPTION
Hi @carlesarnal ,

I have changed the `apiVersion` from `v1` to `template.openshift.io/v1` as we discussed before, to avoid an error like this: `no matches for kind "Template" in version "v1”`.

Thanks for reviewing.