### PR TITLE
Fix : Bump Postgresql version from 42.2.20 to 42.2.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <version.org.jsonschema2pojo>1.2.1</version.org.jsonschema2pojo>
         <version.org.keycloak>23.0.7</version.org.keycloak>
         <version.mysql>8.0.22</version.mysql>
-        <version.org.postgresql>42.2.20</version.org.postgresql>
+        <version.org.postgresql>42.2.28</version.org.postgresql>
         <version.org.slf4j>2.0.12</version.org.slf4j>
         <version.scala>2.13.13</version.scala>
         <version.infinispan>14.0.25.Final</version.infinispan>


### PR DESCRIPTION
Hello, 

Version 42.2.20 is a vulnerable version of postgresql JDBC (affected by CVE-2024-1597): https://github.com/pgjdbc/pgjdbc/security/advisories/GHSA-24rp-q3w6-vc56

Note that the PreferQueryMode=SIMPLE must be activated for the vulnerability to be exploitable.

However, even if this configuration is not activated, it is still a good practice to use the new version of Postgresql JDBC.

Regards,
Simon

![CVE-2024-1597](https://github.com/Apicurio/apicurio-studio/assets/48290387/2d8fd20e-bf46-416d-bdc2-0de930adcc14)