### PR TITLE
Use postgresql image based on centos stream

### DIFF
--- a/integration-tests/src/test/resources/infra/sql/postgresql.yml
+++ b/integration-tests/src/test/resources/infra/sql/postgresql.yml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: postgresql
-          image: quay.io/centos7/postgresql-13-centos7
+          image: quay.io/sclorg/postgresql-13-c8s
           ports:
             - containerPort: 5432
           env:


### PR DESCRIPTION
Copy-pasted from https://github.com/Apicurio/apicurio-registry/pull/4510

The old image does not exist anymore.