### PR TITLE
Vendor extension support in OpenAPI via dynamic forms

### DIFF
--- a/app/src/main/java/io/apicurio/studio/rest/v1/impl/SystemResourceImpl.java
+++ b/app/src/main/java/io/apicurio/studio/rest/v1/impl/SystemResourceImpl.java
@@ -1,13 +1,21 @@
 package io.apicurio.studio.rest.v1.impl;
 
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.apicurio.studio.StudioAppException;
 import io.apicurio.studio.rest.v1.SystemResource;
+import io.apicurio.studio.rest.v1.beans.OpenApiVendorExtension;
 import io.apicurio.studio.rest.v1.beans.SystemInfo;
 import io.apicurio.studio.rest.v1.beans.UserInterfaceConfig;
 import io.apicurio.studio.rest.v1.beans.UserInterfaceConfigAuth;
@@ -34,6 +42,8 @@ public class SystemResourceImpl implements SystemResource {
 
     @ConfigProperty(name = "apicurio.app.git.commit-id")
     Optional<String> commitIdFull;
+    
+    private List<OpenApiVendorExtension> openApiVendorExtensionCache;
 
     @Override
     public SystemInfo getSystemInfo() {
@@ -85,5 +95,28 @@ public class SystemResourceImpl implements SystemResource {
             rval.setOptions(options);
         }
         return rval;
+    }
+    
+    /**
+     * @see io.apicurio.studio.rest.v1.SystemResource#getOpenApiVendorExtensions()
+     */
+    @Override
+    public List<OpenApiVendorExtension> getOpenApiVendorExtensions() {
+        if (!this.uiConfig.openApiVendorExtensions.isPresent()) {
+            return Collections.emptyList();
+        }
+
+        if (openApiVendorExtensionCache == null) {
+            try {
+                URL url = new URL(uiConfig.openApiVendorExtensions.get());
+                try (InputStream stream = url.openStream()) {
+                    ObjectMapper mapper = new ObjectMapper();
+                    openApiVendorExtensionCache = mapper.readerForListOf(OpenApiVendorExtension.class).readValue(stream);
+                }
+            } catch (Exception e) {
+                throw new StudioAppException("Error loading configured OpenAPI vendor extensions.", e);
+            }
+        }
+        return openApiVendorExtensionCache;
     }
 }

--- a/app/src/main/java/io/apicurio/studio/ui/UserInterfaceConfigProperties.java
+++ b/app/src/main/java/io/apicurio/studio/ui/UserInterfaceConfigProperties.java
@@ -16,6 +16,8 @@
 
 package io.apicurio.studio.ui;
 
+import java.util.Optional;
+
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import io.apicurio.common.apps.config.Info;
@@ -59,5 +61,9 @@ public class UserInterfaceConfigProperties {
     @ConfigProperty(name = "apicurio.ui.editors.url", defaultValue = "/editors/")
     @Info(category = "ui", description = "URL to the 'editors' UI component", availableSince = "1.0.0")
     public String editorsUrl;
+
+    @ConfigProperty(name = "apicurio.ui.openapi.vendor-extensions.url")
+    @Info(category = "ui", description = "URL to a JSON file containing OpenAPI vendor extensions", availableSince = "1.0.0")
+    public Optional<String> openApiVendorExtensions;
 
 }

--- a/app/src/main/resources-unfiltered/META-INF/apis/studio/v1/studio-api-v1.json
+++ b/app/src/main/resources-unfiltered/META-INF/apis/studio/v1/studio-api-v1.json
@@ -1041,6 +1041,13 @@
                     "schema": {
                     },
                     "model": {
+                    },
+                    "components": {
+                        "description": "",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 },
                 "example": {
@@ -1083,7 +1090,11 @@
                         "state": "ST",
                         "postalCode": "05432",
                         "country": "USA"
-                    }
+                    },
+                    "components": [
+                        "schema",
+                        "operation"
+                    ]
                 }
             }
         },

--- a/app/src/main/resources-unfiltered/META-INF/apis/studio/v1/studio-api-v1.json
+++ b/app/src/main/resources-unfiltered/META-INF/apis/studio/v1/studio-api-v1.json
@@ -451,6 +451,36 @@
                 }
             ]
         },
+        "/system/uiConfig/openapi/vendorExtensions": {
+            "summary": "Gets all configured vendor extensions for OpenAPI editing",
+            "description": "This endpoint returns a collection of vendor extensions that can be used by the\nOpenAPI editor when a user wants to add `x-vendor` style extension properties\nto their design.",
+            "get": {
+                "tags": [
+                    "System"
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/OpenApiVendorExtension"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "A list of vendor extensions."
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/ServerError"
+                    }
+                },
+                "operationId": "getOpenApiVendorExtensions",
+                "summary": "Get all OpenAPI vendor extensions",
+                "description": "Returns the UI configuration of vendor extensions for the OpenAPI editor.\n\nThis operation may fail for one of the following reasons:\n\n* A server error occurred (HTTP error `500`)\n"
+            }
+        },
         "x-codegen-contextRoot": "/apis/studio/v1"
     },
     "components": {
@@ -992,6 +1022,68 @@
                 "example": {
                     "error_code": 500,
                     "message": "An error occurred somewhere."
+                }
+            },
+            "OpenApiVendorExtension": {
+                "title": "Root Type for OpenApiVendorExtension",
+                "description": "",
+                "required": [
+                    "name",
+                    "schema",
+                    "model"
+                ],
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "pattern": "^x-.*$",
+                        "type": "string"
+                    },
+                    "schema": {
+                    },
+                    "model": {
+                    }
+                },
+                "example": {
+                    "name": "x-apicurio-address",
+                    "schema": {
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "title": "Address",
+                        "type": "object",
+                        "properties": {
+                            "street": {
+                                "type": "string",
+                                "title": "Street"
+                            },
+                            "city": {
+                                "type": "string",
+                                "title": "City"
+                            },
+                            "state": {
+                                "type": "string",
+                                "title": "State"
+                            },
+                            "postalCode": {
+                                "type": "string",
+                                "title": "Zipcode"
+                            },
+                            "country": {
+                                "type": "string",
+                                "title": "Country"
+                            }
+                        },
+                        "required": [
+                            "street",
+                            "city",
+                            "country"
+                        ]
+                    },
+                    "model": {
+                        "street": "12345 Main St",
+                        "city": "Springfield",
+                        "state": "ST",
+                        "postalCode": "05432",
+                        "country": "USA"
+                    }
                 }
             }
         },

--- a/ui/ui-app/src/models/system/VendorExtension.ts
+++ b/ui/ui-app/src/models/system/VendorExtension.ts
@@ -4,5 +4,6 @@ export interface VendorExtension {
     name: string;
     schema: any;
     model: any;
+    components: string[];
 
 }

--- a/ui/ui-app/src/models/system/VendorExtension.ts
+++ b/ui/ui-app/src/models/system/VendorExtension.ts
@@ -1,0 +1,8 @@
+
+export interface VendorExtension {
+
+    name: string;
+    schema: any;
+    model: any;
+
+}

--- a/ui/ui-app/src/models/system/index.ts
+++ b/ui/ui-app/src/models/system/index.ts
@@ -1,1 +1,2 @@
 export * from "./SystemInfo";
+export * from "./VendorExtension";

--- a/ui/ui-app/src/services/useSystemService.ts
+++ b/ui/ui-app/src/services/useSystemService.ts
@@ -2,9 +2,10 @@ import { AuthService, useAuth } from "@apicurio/common-ui-components";
 import { SystemInfo } from "@models/system/SystemInfo.ts";
 import { createEndpoint, createOptions, httpGet } from "@utils/rest.utils.ts";
 import { ApicurioStudioConfig, useConfigService } from "@services/useConfigService.ts";
+import { VendorExtension } from "@models/system";
 
 
-const getInfo = async (appConfig: ApicurioStudioConfig, auth: AuthService, ): Promise<SystemInfo> => {
+const getInfo = async (appConfig: ApicurioStudioConfig, auth: AuthService): Promise<SystemInfo> => {
     console.debug("[SystemService] Getting system info.");
     const token: string | undefined = await auth.getToken();
 
@@ -15,8 +16,21 @@ const getInfo = async (appConfig: ApicurioStudioConfig, auth: AuthService, ): Pr
     return httpGet<SystemInfo>(endpoint, createOptions(headers));
 };
 
+const getOpenApiVendorExtensions = async (appConfig: ApicurioStudioConfig, auth: AuthService): Promise<VendorExtension[]> => {
+    // TODO cache the vendor extensions?
+    console.debug("[SystemService] Getting openapi vendor extensions.");
+    const token: string | undefined = await auth.getToken();
+
+    const endpoint: string = createEndpoint(appConfig.apis.studio, "/system/uiConfig/openapi/vendorExtensions");
+    const headers: any = {
+        "Authorization": `Bearer ${token}`
+    };
+    return httpGet<VendorExtension[]>(endpoint, createOptions(headers));
+};
+
 export interface SystemService {
     getInfo(): Promise<SystemInfo>;
+    getOpenApiVendorExtensions(): Promise<VendorExtension[]>;
 }
 
 
@@ -27,6 +41,9 @@ export const useSystemService: () => SystemService = (): SystemService => {
     return {
         getInfo(): Promise<SystemInfo> {
             return getInfo(appConfig, auth);
+        },
+        getOpenApiVendorExtensions(): Promise<VendorExtension[]> {
+            return getOpenApiVendorExtensions(appConfig, auth);
         }
     };
 };

--- a/ui/ui-editors/package-lock.json
+++ b/ui/ui-editors/package-lock.json
@@ -17,6 +17,8 @@
                 "@angular/platform-browser-dynamic": "17.3.2",
                 "@angular/router": "17.3.2",
                 "@apicurio/data-models": "1.1.27",
+                "@ngx-formly/bootstrap": "6.3.0",
+                "@ngx-formly/core": "6.3.0",
                 "@patternfly/patternfly": "1.0.250",
                 "apicurio-ts-core": "0.1.3",
                 "bootstrap": "5.3.3",
@@ -2883,6 +2885,30 @@
                 "@angular/compiler-cli": "^17.0.0",
                 "typescript": ">=5.2 <5.5",
                 "webpack": "^5.54.0"
+            }
+        },
+        "node_modules/@ngx-formly/bootstrap": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/@ngx-formly/bootstrap/-/bootstrap-6.3.0.tgz",
+            "integrity": "sha512-1++lF/Xde5NPRGh2Ce0QJl6VQbNKAHjrtIsLsRPQ3B0Ef81PBe1Makb8ycqKd3G9EWc7k+OFTQJ9Tpj7teTmiA==",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "@ngx-formly/core": "6.3.0",
+                "bootstrap": "^5.0.0"
+            }
+        },
+        "node_modules/@ngx-formly/core": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/@ngx-formly/core/-/core-6.3.0.tgz",
+            "integrity": "sha512-9qCoPdLLVShoruzXeJUjMdIhfIlHCI+TggA3Wc01ISHTK2vXx1gNIFLuS+hez3JEzu8nIDRuA/nWqj4j8fJCNg==",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "@angular/forms": ">=13.2.0",
+                "rxjs": "^6.5.3 || ^7.0.0"
             }
         },
         "node_modules/@nodelib/fs.scandir": {

--- a/ui/ui-editors/package.json
+++ b/ui/ui-editors/package.json
@@ -19,6 +19,8 @@
         "@angular/router": "17.3.2",
         "@patternfly/patternfly": "1.0.250",
         "@apicurio/data-models": "1.1.27",
+        "@ngx-formly/bootstrap": "6.3.0",
+        "@ngx-formly/core": "6.3.0",
         "apicurio-ts-core": "0.1.3",
         "bootstrap": "5.3.3",
         "brace": "0.11.1",

--- a/ui/ui-editors/src/app/app.component.html
+++ b/ui/ui-editors/src/app/app.component.html
@@ -6,7 +6,7 @@
 </div>
 <div *ngIf="isShowEditor" class="studio-editor">
     <div class="content-editor">
-        <openapi-editor #openapiEditor *ngIf="config.content.type === 'OPENAPI'" [api]="api"></openapi-editor>
+        <openapi-editor #openapiEditor *ngIf="config.content.type === 'OPENAPI'" [api]="api" [config]="config"></openapi-editor>
         <asyncapi-editor #asyncapiEditor *ngIf="config.content.type === 'ASYNCAPI'" [api]="api"></asyncapi-editor>
     </div>
 </div>

--- a/ui/ui-editors/src/app/components/editors/openapi-editor.component.html
+++ b/ui/ui-editors/src/app/components/editors/openapi-editor.component.html
@@ -1,5 +1,5 @@
 <div class="openapi-editor" id="openapi-editor">
     <oai-editor #apiEditor [api]="api" [embedded]="true" (onCommandExecuted)="documentChanged()"
                 (onUndo)="documentChanged()" (onRedo)="documentChanged()"
-                [features]="{ componentImports: false, validationSettings: false }"></oai-editor>
+                [features]="editorFeatures()"></oai-editor>
 </div>

--- a/ui/ui-editors/src/app/components/editors/openapi-editor.component.ts
+++ b/ui/ui-editors/src/app/components/editors/openapi-editor.component.ts
@@ -21,6 +21,8 @@ import {EditorComponent} from "./editor.component";
 import {WindowRef} from "../../services/window-ref.service";
 import {ApiDefinition} from "../../editor/_models/api.model";
 import {OaiEditorComponent} from "../../editor/oaieditor.component";
+import {EditingInfo} from "../../models/editingInfo.model";
+import {ApiEditorComponentFeatures} from "../../editor/_models/features.model";
 
 
 @Component({
@@ -30,8 +32,8 @@ import {OaiEditorComponent} from "../../editor/oaieditor.component";
 })
 export class OpenApiEditorComponent implements EditorComponent {
 
-    // @ts-ignore
     @Input() api: ApiDefinition;
+    @Input() config: EditingInfo;
 
     @ViewChild("apiEditor") apiEditor: OaiEditorComponent | undefined;
 
@@ -63,6 +65,14 @@ export class OpenApiEditorComponent implements EditorComponent {
     public getValue(): string {
         const value: ApiDefinition = this.apiEditor.getValue();
         return JSON.stringify(value.spec, null, 4);
+    }
+
+    public editorFeatures(): ApiEditorComponentFeatures {
+        return {
+            componentImports: this.config.features.allowImports || false,
+            validationSettings: this.config.features.allowCustomValidations || false,
+            vendorExtensions: this.config.openapi.vendorExtensions || []
+        };
     }
 
 }

--- a/ui/ui-editors/src/app/editor.module.ts
+++ b/ui/ui-editors/src/app/editor.module.ts
@@ -18,7 +18,7 @@
 import {NgModule} from "@angular/core";
 
 import {CommonModule} from "@angular/common";
-import {FormsModule} from "@angular/forms";
+import {FormsModule, ReactiveFormsModule} from "@angular/forms";
 import {BsDropdownModule} from "ngx-bootstrap/dropdown";
 import {ModalModule, BsModalService} from "ngx-bootstrap/modal";
 
@@ -174,10 +174,100 @@ import {DivAutoHeight, TextAreaAutosize, TextBoxAutosize} from "./editor/_direct
 import {MarkdownComponent} from "./editor/_components/common/markdown.component";
 import {MarkdownSummaryComponent} from "./editor/_components/common/markdown-summary.component";
 import {MarkdownEditorComponent} from "./editor/_components/common/markdown-editor.component";
+import {FormlyBootstrapModule} from "@ngx-formly/bootstrap";
+import {FormlyFieldConfig, FormlyModule} from "@ngx-formly/core";
+import {NullTypeComponent} from "./editor/_components/dynamicforms/types/null.type";
+import {ArrayTypeComponent} from "./editor/_components/dynamicforms/types/array.type";
+import {ObjectTypeComponent} from "./editor/_components/dynamicforms/types/object.type";
+import {DynamicFormComponent} from "./editor/_components/dynamicforms/dynamic-form.component";
+
+export function minItemsValidationMessage(err, field: FormlyFieldConfig): string {
+    return `should NOT have fewer than ${field.templateOptions.minItems} items`;
+}
+
+export function maxItemsValidationMessage(err, field: FormlyFieldConfig): string {
+    return `should NOT have more than ${field.templateOptions.maxItems} items`;
+}
+
+export function minlengthValidationMessage(err, field: FormlyFieldConfig): string {
+    return `should NOT be shorter than ${field.templateOptions.minLength} characters`;
+}
+
+export function maxlengthValidationMessage(err, field: FormlyFieldConfig): string {
+    return `should NOT be longer than ${field.templateOptions.maxLength} characters`;
+}
+
+export function minValidationMessage(err, field: FormlyFieldConfig): string {
+    return `should be >= ${field.templateOptions.min}`;
+}
+
+export function maxValidationMessage(err, field: FormlyFieldConfig): string {
+    return `should be <= ${field.templateOptions.max}`;
+}
+
+export function multipleOfValidationMessage(err, field: FormlyFieldConfig): string {
+    return `should be multiple of ${field.templateOptions.step}`;
+}
+
+export function exclusiveMinimumValidationMessage(err, field: FormlyFieldConfig): string {
+    return `should be > ${field.templateOptions.step}`;
+}
+
+export function exclusiveMaximumValidationMessage(err, field: FormlyFieldConfig): string {
+    return `should be < ${field.templateOptions.step}`;
+}
+
+export function constValidationMessage(err, field: FormlyFieldConfig): string {
+    return `should be equal to constant "${field.templateOptions.const}"`;
+}
 
 @NgModule({
     imports: [
-        CommonModule, FormsModule, ModalModule, BsDropdownModule
+        CommonModule, FormsModule, ModalModule, BsDropdownModule, ReactiveFormsModule,
+        FormlyModule.forRoot({
+            validationMessages: [
+                { name: "required", message: "This field is required" },
+                { name: "null", message: "should be null" },
+                { name: "minlength", message: minlengthValidationMessage },
+                { name: "maxlength", message: maxlengthValidationMessage },
+                { name: "min", message: minValidationMessage },
+                { name: "max", message: maxValidationMessage },
+                { name: "multipleOf", message: multipleOfValidationMessage },
+                { name: "exclusiveMinimum", message: exclusiveMinimumValidationMessage },
+                { name: "exclusiveMaximum", message: exclusiveMaximumValidationMessage },
+                { name: "minItems", message: minItemsValidationMessage },
+                { name: "maxItems", message: maxItemsValidationMessage },
+                { name: "uniqueItems", message: "should NOT have duplicate items" },
+                { name: "const", message: constValidationMessage },
+            ],
+            types: [
+                { name: "string", extends: "input" },
+                {
+                    name: "number",
+                    extends: "input",
+                    defaultOptions: {
+                        templateOptions: {
+                            type: "number",
+                        },
+                    },
+                },
+                {
+                    name: "integer",
+                    extends: "input",
+                    defaultOptions: {
+                        templateOptions: {
+                            type: "number",
+                        },
+                    },
+                },
+                { name: "boolean", extends: "checkbox" },
+                { name: "enum", extends: "select" },
+                { name: "null", component: NullTypeComponent, wrappers: ["form-field"] },
+                { name: "array", component: ArrayTypeComponent },
+                { name: "object", component: ObjectTypeComponent }
+            ],
+        }),
+        FormlyBootstrapModule
     ],
     declarations: [
         ValidationIconComponent, ServerUrlComponent, SearchComponent, SchemaTypeComponent, ResponseItemComponent,
@@ -216,7 +306,7 @@ import {MarkdownEditorComponent} from "./editor/_components/common/markdown-edit
         CloneResponseDefinitionDialogComponent, PropertiesSectionComponent, InheritanceSchemasSectionComponent,
         SchemaRowComponent, AddSchemaDialogComponent, CloneChannelDialogComponent, ExtensionsSectionComponent,
         ExtensionRowComponent, JsonSummaryComponent, InlineJsonEditorComponent, AddExtensionDialogComponent,
-        OaiEditorComponent
+        OaiEditorComponent, ArrayTypeComponent, ObjectTypeComponent, NullTypeComponent, DynamicFormComponent
     ],
     providers: [
         BsModalService,

--- a/ui/ui-editors/src/app/editor/_components/common/drop-down.component.html
+++ b/ui/ui-editors/src/app/editor/_components/common/drop-down.component.html
@@ -11,8 +11,8 @@
                    [(ngModel)]="criteria" (ngModelChange)="filterOptions()" (keypress)="inputKeypress($event)">
         </li>
         <li class="divider" *ngIf="shouldShowFilter()"></li>
-        <li role="presentation" *ngFor="let option of filteredOptions" [class.divider]="option.divider" [class.disabled]="option.disabled">
-            <a *ngIf="!option.divider" role="menuitem" tabindex="-1" (click)="option.disabled ? false : setValue(option.value)">{{ option.name }}</a>
+        <li role="presentation" *ngFor="let option of filteredOptions" [class.divider]="option.isDivider()" [class.disabled]="option.isDisabled()">
+            <a *ngIf="!option.isDivider()" role="menuitem" tabindex="-1" (click)="optionClicked(option)">{{ option.getName() }}</a>
         </li>
         <li role="presentation" *ngIf="!hasOptions()">
             <span>{{ noOptionsLabel }}</span>

--- a/ui/ui-editors/src/app/editor/_components/common/drop-down.component.ts
+++ b/ui/ui-editors/src/app/editor/_components/common/drop-down.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import {Component, ElementRef, EventEmitter, Input, Output, ViewChild, ViewEncapsulation} from "@angular/core";
+import {Component, ElementRef, EventEmitter, Input, Output, ViewChild} from "@angular/core";
 
 export abstract class DropDownOption {
 
@@ -32,24 +32,28 @@ export class DropDownOptionValue extends DropDownOption {
     public value: any;
     public disabled: boolean = false;
 
-    public constructor(name: string, value: any, disabled: boolean = false) {
+    public constructor(name: string, value: any, disabled?: boolean) {
         super();
         this.name = name;
         this.value = value;
-        this.disabled = disabled;
+        if (disabled !== undefined) {
+            this.disabled = disabled;
+        } else {
+            this.disabled = false;
+        }
     }
 
     public isDivider(): boolean {
         return false;
     }
-    public getName() {
+    public getName(): string {
         return this.name;
     }
-    public getValue() {
+    public getValue(): any {
         return this.value;
     }
     public isDisabled(): boolean {
-        throw this.disabled;
+        return this.disabled;
     }
 }
 
@@ -61,25 +65,22 @@ export class DropDownOptionDivider extends DropDownOption {
         return true;
     }
 
-    public getName() {
-        throw new Error("DropDownOptionDivider does not contain a name. "
-            + "Use DropDownOption#isDivider() to prevent this error.");
+    public getName(): any {
+        return "";
     }
 
-    public getValue() {
-        throw new Error("DropDownOptionDivider does not contain a value. "
-            + "Use DropDownOption#isDivider() to prevent this error.");
+    public getValue(): any {
+        return undefined;
     }
 
     public isDisabled(): boolean {
-        throw new Error("DropDownOptionDivider cannot be disabled. "
-            + "Use DropDownOption#isDivider() to prevent this error.");
+        return false;
     }
 }
 
 /**
-  * Static instance for reusability
-  */
+ * Static instance for reusability
+ */
 export let DIVIDER: DropDownOption = new DropDownOptionDivider();
 
 @Component({
@@ -153,7 +154,7 @@ export class DropDownComponent {
     }
 
     public hasValue(): boolean {
-        for (let option of this.options) {
+        for (const option of this.options) {
             if (!option.isDivider() && option.getValue() === this.value) {
                 return true;
             }
@@ -162,7 +163,7 @@ export class DropDownComponent {
     }
 
     public displayValue(): string {
-        for (let option of this.options) {
+        for (const option of this.options) {
             if (!option.isDivider() && option.getValue() === this.value) {
                 return option.getName();
             }
@@ -201,6 +202,12 @@ export class DropDownComponent {
 
     public shouldShowFilter(): boolean {
         return this._options && this._options.length > this.filterItemCountThreshold;
+    }
+
+    public optionClicked(option: DropDownOption): void {
+        if (!option.isDisabled() && !option.isDivider()) {
+            this.setValue(option.getValue());
+        }
     }
 
 }

--- a/ui/ui-editors/src/app/editor/_components/dialogs/add-extension.component.css
+++ b/ui/ui-editors/src/app/editor/_components/dialogs/add-extension.component.css
@@ -1,3 +1,7 @@
 #addExtensionModal .modal-dialog .modal-body form textarea {
   min-height: 60px;
 }
+
+.vendor-extension-form {
+    padding: 15px 25px 5px;
+}

--- a/ui/ui-editors/src/app/editor/_components/dialogs/add-extension.component.html
+++ b/ui/ui-editors/src/app/editor/_components/dialogs/add-extension.component.html
@@ -13,21 +13,35 @@
             <div class="modal-body">
                 <p>Enter information about the new extension below and then click <strong>Add</strong>.</p>
                 <form id="addextension-form" class="form-horizontal" (submit)="add()" #addExtensionForm="ngForm" data-dismiss="modal">
-                    <div class="form-group">
-                        <label class="col-sm-2 control-label required" for="extension">Name</label>
-                        <div class="col-sm-10">
-                            <drop-down id="extension-name" [id]="'extension-name'" [value]="extensionName" [options]="_extensionNameOptions"
-                                       (onValueChange)="selectExtension($event)" noSelectionLabel="Choose property name"></drop-down>
+                    <div *ngIf="hasVendorExtensions()">
+                        <div class="form-group">
+                            <label class="col-sm-2 control-label required" for="extension-name">Name</label>
+                            <div class="col-sm-10">
+                                <drop-down id="extension-name" [id]="'extension-name'" [value]="extensionName" [options]="_extensionNameOptions"
+                                           (onValueChange)="selectExtension($event)" noSelectionLabel="Choose property name"></drop-down>
+                            </div>
+                        </div>
+                        <div class="form-group" *ngIf="extensionName === 'custom'">
+                            <label class="col-sm-2 control-label" for="extension-v"></label>
+                            <div class="col-sm-10">
+                                <input #addExtensionInput name="extension" type="text" id="extension-v" class="form-control" placeholder="Extension Name"
+                                       required [(ngModel)]="name" (ngModelChange)="validateName($event)" #nameInput="ngModel">
+                                <div class="form-error-message error" *ngIf="extensionExists">Extension already exists.</div>
+                                <div class="form-error-message error" *ngIf="!nameValid">Name must begin with "x-".</div>
+                                <form-error-message [inputModel]="nameInput" [type]="'required'">Name is required.</form-error-message>
+                            </div>
                         </div>
                     </div>
-                    <div class="form-group" *ngIf="extensionName === 'custom'">
-                        <label class="col-sm-2 control-label" for="extension"></label>
-                        <div class="col-sm-10">
-                            <input #addExtensionInput name="extension" type="text" id="extension" class="form-control" placeholder="Extension Name"
-                                   required [(ngModel)]="name" (ngModelChange)="validateName($event)" #nameInput="ngModel">
-                            <div class="form-error-message error" *ngIf="extensionExists">Extension already exists.</div>
-                            <div class="form-error-message error" *ngIf="!nameValid">Name must begin with "x-".</div>
-                            <form-error-message [inputModel]="nameInput" [type]="'required'">Name is required.</form-error-message>
+                    <div *ngIf="!hasVendorExtensions()">
+                        <div class="form-group">
+                            <label class="col-sm-2 control-label required" for="extension-nov">Name</label>
+                            <div class="col-sm-10">
+                                <input #addExtensionInput name="extension" type="text" id="extension-nov" class="form-control" placeholder="Extension Name"
+                                       required [(ngModel)]="name" (ngModelChange)="validateName($event)" #nameInput="ngModel">
+                                <div class="form-error-message error" *ngIf="extensionExists">Extension already exists.</div>
+                                <div class="form-error-message error" *ngIf="!nameValid">Name must begin with "x-".</div>
+                                <form-error-message [inputModel]="nameInput" [type]="'required'">Name is required.</form-error-message>
+                            </div>
                         </div>
                     </div>
                     <div class="form-group" *ngIf="extensionName === 'custom'">

--- a/ui/ui-editors/src/app/editor/_components/dialogs/add-extension.component.html
+++ b/ui/ui-editors/src/app/editor/_components/dialogs/add-extension.component.html
@@ -16,6 +16,13 @@
                     <div class="form-group">
                         <label class="col-sm-2 control-label required" for="extension">Name</label>
                         <div class="col-sm-10">
+                            <drop-down id="extension-name" [id]="'extension-name'" [value]="extensionName" [options]="_extensionNameOptions"
+                                       (onValueChange)="selectExtension($event)" noSelectionLabel="Choose property name"></drop-down>
+                        </div>
+                    </div>
+                    <div class="form-group" *ngIf="extensionName === 'custom'">
+                        <label class="col-sm-2 control-label" for="extension"></label>
+                        <div class="col-sm-10">
                             <input #addExtensionInput name="extension" type="text" id="extension" class="form-control" placeholder="Extension Name"
                                    required [(ngModel)]="name" (ngModelChange)="validateName($event)" #nameInput="ngModel">
                             <div class="form-error-message error" *ngIf="extensionExists">Extension already exists.</div>
@@ -23,7 +30,7 @@
                             <form-error-message [inputModel]="nameInput" [type]="'required'">Name is required.</form-error-message>
                         </div>
                     </div>
-                    <div class="form-group">
+                    <div class="form-group" *ngIf="extensionName === 'custom'">
                         <label class="col-sm-2 control-label" for="extension-value">Value</label>
                         <div class="col-sm-10">
                             <code-editor [mode]="valueEditorMode()" #codeEditor
@@ -35,11 +42,21 @@
                             <div class="form-error-message error" *ngIf="!valueValid">Valid JSON required.</div>
                         </div>
                     </div>
+                    <div class="form-group" *ngIf="extensionName !== 'custom'">
+                        <div class="col-sm-12">
+                            <div class="vendor-extension-form">
+                                <dynamic-form [schema]="extensionSchema"
+                                              [model]="extensionModel"
+                                              (onModelChange)="onDynamicFormModelChange($event)"
+                                              (onValid)="onDynamicFormValid($event)"></dynamic-form>
+                            </div>
+                        </div>
+                    </div>
                 </form>
             </div>
             <div class="notice-of-required modal-notice-of-required">The fields marked with <span class="required-icon">*</span> are required.</div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-primary" (click)="add()" [disabled]="!addExtensionForm.form.valid || extensionExists || !valueValid || !nameValid">Add</button>
+                <button type="button" class="btn btn-primary" (click)="add()" [disabled]="extensionExists || !valueValid || !nameValid">Add</button>
                 <button type="button" class="btn btn-default" (click)="cancel()">Cancel</button>
             </div>
         </div>

--- a/ui/ui-editors/src/app/editor/_components/dialogs/add-extension.component.ts
+++ b/ui/ui-editors/src/app/editor/_components/dialogs/add-extension.component.ts
@@ -21,154 +21,9 @@ import {ExtensibleNode} from "@apicurio/data-models";
 import {CodeEditorMode} from "../common/code-editor.component";
 import {LoggerService} from "../../../services/logger.service";
 import {DIVIDER, DropDownOption, DropDownOptionValue} from "../common/drop-down.component";
+import {FeaturesService} from "../../_services/features.service";
+import {VendorExtension} from "../../_models/features.model";
 
-
-
-const ADDRESS_SCHEMA: any = {
-    $schema: "http://json-schema.org/draft-07/schema#",
-    title: "Address",
-    type: "object",
-    properties: {
-        street: {
-            type: "string",
-            title: "Street"
-        },
-        city: {
-            type: "string",
-            title: "City"
-        },
-        state: {
-            type: "string",
-            title: "State"
-        },
-        postalCode: {
-            type: "string",
-            title: "Zipcode"
-        },
-        country: {
-            type: "string",
-            title: "Country"
-        }
-    },
-    required: ["street", "city", "country"]
-};
-
-const ADDRESS_MODEL: any = {
-    street: null,
-    city: "",
-    state: "",
-    postalCode: "",
-    country: ""
-};
-
-const KUADRANT_SCHEMA: any = {
-    $schema: "http://json-schema.org/draft-07/schema#",
-    type: "object",
-    title: "Route",
-    properties: {
-        route: {
-            type: "object",
-            properties: {
-                name: {
-                    type: "string",
-                    title: "Name"
-                },
-                namespace: {
-                    type: "string",
-                    title: "Namespace"
-                },
-                labels: {
-                    type: "object",
-                    title: "Labels",
-                    patternProperties: {
-                        ".{1,}": {
-                            type: "string",
-                            title: "Value"
-                        }
-                    }
-                },
-                hostnames: {
-                    type: "array",
-                    title: "Hostnames",
-                    items: {
-                        type: "string",
-                        title: "Hostname"
-                    }
-                },
-                parentRefs: {
-                    type: "array",
-                    title: "Parent Refs",
-                    items: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string",
-                                title: "Name"
-                            },
-                            namespace: {
-                                type: "string",
-                                title: "Namespace"
-                            }
-                        },
-                        required: ["name", "namespace"]
-                    }
-                }
-            },
-            required: ["name", "namespace", "labels", "hostnames", "parentRefs"]
-        }
-    },
-    required: ["route"]
-};
-
-const KUADRANT_MODEL: any = {
-    route: {
-        name: "",
-        namespace: "",
-        labels: {
-        },
-        hostnames: [
-            "example.com"
-        ],
-        parentRefs: [
-        ]
-    }
-};
-
-const CODEGEN_SCHEMA: any = {
-    $schema: "http://json-schema.org/draft-07/schema#",
-    type: "object",
-    properties: {
-        "suppress-date-time-formatting": {
-            type: "boolean",
-            title: "Suppress Datetime Formatting"
-        },
-        "bean-annotations": {
-            type: "array",
-            title: "Bean Annotations",
-            items: {
-                type: "object",
-                properties: {
-                    annotation: {
-                        type: "string",
-                        title: "Annotation"
-                    },
-                    excludeEnums: {
-                        type: "boolean",
-                        title: "Exclude Enums"
-                    }
-                },
-                required: ["annotation"]
-            }
-        }
-    },
-    required: []
-};
-
-const CODEGEN_MODEL: any = {
-    "suppress-date-time-formatting": false,
-    "bean-annotations": [
-    ]
-};
 
 @Component({
     selector: "add-extension-dialog",
@@ -205,21 +60,15 @@ export class AddExtensionDialogComponent {
     nameValid: boolean = false;
     valueValid: boolean = false;
 
-    constructor(private logger: LoggerService) {
-        this.vendorExtensionMap = {
-            "x-address": {
-                schema: ADDRESS_SCHEMA,
-                model: ADDRESS_MODEL
-            },
-            "x-codegen": {
-                schema: CODEGEN_SCHEMA,
-                model: CODEGEN_MODEL
-            },
-            "x-kuadrant": {
-                schema: KUADRANT_SCHEMA,
-                model: KUADRANT_MODEL
-            }
-        };
+    constructor(private logger: LoggerService, private features: FeaturesService) {
+        const vendorExtensions: VendorExtension[] = features.getFeatures().vendorExtensions || [];
+        this.vendorExtensionMap = {};
+        vendorExtensions.forEach(vext => {
+            this.vendorExtensionMap[vext.name] = {
+                schema: vext.schema,
+                model: vext.model
+            };
+        });
         this._extensionNameOptions = [
             new DropDownOptionValue("Custom property", "custom"),
             DIVIDER
@@ -334,5 +183,9 @@ export class AddExtensionDialogComponent {
 
     cloneModel(model: any): any {
         return JSON.parse(JSON.stringify(model));
+    }
+
+    hasVendorExtensions(): boolean {
+        return Object.getOwnPropertyNames(this.vendorExtensionMap).length > 0;
     }
 }

--- a/ui/ui-editors/src/app/editor/_components/dialogs/add-extension.component.ts
+++ b/ui/ui-editors/src/app/editor/_components/dialogs/add-extension.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import {Component, ElementRef, EventEmitter, Output, QueryList, ViewChildren} from "@angular/core";
+import {Component, ElementRef, EventEmitter, Input, Output, QueryList, ViewChildren} from "@angular/core";
 import {ModalDirective} from "ngx-bootstrap/modal";
 import {ExtensibleNode} from "@apicurio/data-models";
 import {CodeEditorMode} from "../common/code-editor.component";
@@ -23,6 +23,7 @@ import {LoggerService} from "../../../services/logger.service";
 import {DIVIDER, DropDownOption, DropDownOptionValue} from "../common/drop-down.component";
 import {FeaturesService} from "../../_services/features.service";
 import {VendorExtension} from "../../_models/features.model";
+import {ComponentType} from "../../_models/component-type.model";
 
 
 @Component({
@@ -32,6 +33,7 @@ import {VendorExtension} from "../../_models/features.model";
 })
 export class AddExtensionDialogComponent {
 
+    @Input() forComponent: ComponentType;
     @Output() onAdd: EventEmitter<any> = new EventEmitter<any>();
 
     @ViewChildren("addExtensionModal") addExtensionModal: QueryList<ModalDirective>;
@@ -61,21 +63,6 @@ export class AddExtensionDialogComponent {
     valueValid: boolean = false;
 
     constructor(private logger: LoggerService, private features: FeaturesService) {
-        const vendorExtensions: VendorExtension[] = features.getFeatures().vendorExtensions || [];
-        this.vendorExtensionMap = {};
-        vendorExtensions.forEach(vext => {
-            this.vendorExtensionMap[vext.name] = {
-                schema: vext.schema,
-                model: vext.model
-            };
-        });
-        this._extensionNameOptions = [
-            new DropDownOptionValue("Custom property", "custom"),
-            DIVIDER
-        ];
-        Object.getOwnPropertyNames(this.vendorExtensionMap).forEach(name => {
-            this._extensionNameOptions.push(new DropDownOptionValue(name, name));
-        });
     }
 
     /**
@@ -95,6 +82,27 @@ export class AddExtensionDialogComponent {
             }
         });
         this.extensionExists = false;
+        this.configureVendorExtensions();
+    }
+
+    configureVendorExtensions(): void {
+        const vendorExtensions: VendorExtension[] = this.features.getFeatures().vendorExtensions || [];
+        this.vendorExtensionMap = {};
+        vendorExtensions.filter(vext => {
+            return !vext.components || vext.components.length === 0 || vext.components.indexOf(this.forComponent) !== -1;
+        }).forEach(vext => {
+            this.vendorExtensionMap[vext.name] = {
+                schema: vext.schema,
+                model: vext.model
+            };
+        });
+        this._extensionNameOptions = [
+            new DropDownOptionValue("Custom property", "custom"),
+            DIVIDER
+        ];
+        Object.getOwnPropertyNames(this.vendorExtensionMap).forEach(name => {
+            this._extensionNameOptions.push(new DropDownOptionValue(name, name));
+        });
     }
 
     /**

--- a/ui/ui-editors/src/app/editor/_components/dynamicforms/dynamic-form.component.css
+++ b/ui/ui-editors/src/app/editor/_components/dynamicforms/dynamic-form.component.css
@@ -1,0 +1,16 @@
+
+.dynamic-form .mb-3 {
+    margin-bottom: 8px;
+}
+.dynamic-form .mb-3 > label {
+    margin-bottom: 0;
+}
+
+.dynamic-form .mb-3 .row {
+    margin: 0;
+    padding-left: 15px;
+}
+
+.dynamic-form label.form-check-label {
+    margin-left: 5px;
+}

--- a/ui/ui-editors/src/app/editor/_components/dynamicforms/dynamic-form.component.html
+++ b/ui/ui-editors/src/app/editor/_components/dynamicforms/dynamic-form.component.html
@@ -1,0 +1,5 @@
+<div class="dynamic-form" *ngIf="form !== undefined">
+    <form [formGroup]="form">
+        <formly-form [form]="form" [fields]="fields" [model]="model"></formly-form>
+    </form>
+</div>

--- a/ui/ui-editors/src/app/editor/_components/dynamicforms/dynamic-form.component.ts
+++ b/ui/ui-editors/src/app/editor/_components/dynamicforms/dynamic-form.component.ts
@@ -29,13 +29,11 @@ export class DynamicFormComponent implements OnChanges {
             this.form = new FormGroup({});
             this.fields = [this.formlyJsonschema.toFieldConfig(this.schema)];
             this.form.valueChanges.subscribe(changes => {
-                console.info("======> MODEL CHANGED: ", this.model, this.form.valid);
                 this.onModelChange.emit(this.model);
                 this.validate();
             });
         }
         setTimeout(() => {
-            console.info("======> updateValueAndValidity!");
             if (this.form) {
                 this.form.updateValueAndValidity();
             }
@@ -44,9 +42,7 @@ export class DynamicFormComponent implements OnChanges {
     }
 
     private validate(): void {
-        console.info("======> VALIDATING: ", this.isValid, " -> ", this.form.valid);
         if (this.isValid !== this.form.valid) {
-            console.info("======> VALIDATION CHANGED: ", this.form.valid);
             this.onValid.emit(this.form.valid);
         }
         this.isValid = this.form.valid;

--- a/ui/ui-editors/src/app/editor/_components/dynamicforms/dynamic-form.component.ts
+++ b/ui/ui-editors/src/app/editor/_components/dynamicforms/dynamic-form.component.ts
@@ -1,0 +1,55 @@
+import {Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, ViewEncapsulation} from "@angular/core";
+import {FormGroup} from "@angular/forms";
+import {FormlyFieldConfig} from "@ngx-formly/core";
+import {FormlyJsonschema} from "@ngx-formly/core/json-schema";
+import {LoggerService} from "../../../services/logger.service";
+
+@Component({
+    selector: "dynamic-form",
+    templateUrl: "./dynamic-form.component.html",
+    styleUrls: ["./dynamic-form.component.css"],
+    encapsulation: ViewEncapsulation.None
+})
+export class DynamicFormComponent implements OnChanges {
+    @Input() schema: any;
+    @Input() model: any;
+    @Output() onModelChange: EventEmitter<any> = new EventEmitter<any>();
+    @Output() onValid: EventEmitter<boolean> = new EventEmitter<boolean>();
+
+    form: FormGroup = undefined;
+    fields: FormlyFieldConfig[] = undefined;
+    isValid: boolean = undefined;
+
+    constructor(private logger: LoggerService, private formlyJsonschema: FormlyJsonschema) {
+    }
+
+    ngOnChanges(changes: SimpleChanges): void {
+        if (changes.schema) {
+            this.isValid = undefined;
+            this.form = new FormGroup({});
+            this.fields = [this.formlyJsonschema.toFieldConfig(this.schema)];
+            this.form.valueChanges.subscribe(changes => {
+                console.info("======> MODEL CHANGED: ", this.model, this.form.valid);
+                this.onModelChange.emit(this.model);
+                this.validate();
+            });
+        }
+        setTimeout(() => {
+            console.info("======> updateValueAndValidity!");
+            if (this.form) {
+                this.form.updateValueAndValidity();
+            }
+            this.validate();
+        }, 100);
+    }
+
+    private validate(): void {
+        console.info("======> VALIDATING: ", this.isValid, " -> ", this.form.valid);
+        if (this.isValid !== this.form.valid) {
+            console.info("======> VALIDATION CHANGED: ", this.form.valid);
+            this.onValid.emit(this.form.valid);
+        }
+        this.isValid = this.form.valid;
+    }
+
+}

--- a/ui/ui-editors/src/app/editor/_components/dynamicforms/types/array.type.ts
+++ b/ui/ui-editors/src/app/editor/_components/dynamicforms/types/array.type.ts
@@ -1,0 +1,28 @@
+import { Component } from "@angular/core";
+import { FieldArrayType } from "@ngx-formly/core";
+
+@Component({
+    selector: "formly-array-type",
+    template: `
+  <div class="mb-3">
+    <legend *ngIf="to.label">{{ to.label }}</legend>
+    <p *ngIf="to.description">{{ to.description }}</p>
+
+    <div class="alert alert-danger" role="alert" *ngIf="showError && formControl.errors">
+      <formly-validation-message [field]="field"></formly-validation-message>
+    </div>
+
+    <div *ngFor="let field of field.fieldGroup;let i = index;" class="row">
+      <formly-field class="col-10" [field]="field"></formly-field>
+      <div class="col-2 text-right">
+        <button class="btn btn-danger" type="button" (click)="remove(i)">-</button>
+      </div>
+    </div>
+
+    <div class="d-flex flex-row-reverse">
+      <button class="btn btn-primary" type="button" (click)="add()">+</button>
+    </div>
+  </div>
+  `,
+})
+export class ArrayTypeComponent extends FieldArrayType {}

--- a/ui/ui-editors/src/app/editor/_components/dynamicforms/types/null.type.ts
+++ b/ui/ui-editors/src/app/editor/_components/dynamicforms/types/null.type.ts
@@ -1,0 +1,8 @@
+import { Component } from "@angular/core";
+import { FieldType } from "@ngx-formly/core";
+
+@Component({
+    selector: "formly-null-type",
+    template: "",
+})
+export class NullTypeComponent extends FieldType {}

--- a/ui/ui-editors/src/app/editor/_components/dynamicforms/types/object.type.ts
+++ b/ui/ui-editors/src/app/editor/_components/dynamicforms/types/object.type.ts
@@ -1,0 +1,21 @@
+import { Component } from "@angular/core";
+import { FieldType } from "@ngx-formly/core";
+
+@Component({
+    selector: "formly-object-type",
+    template: `
+        <div class="mb-3">
+            <legend *ngIf="to.label">{{ to.label }}</legend>
+            <p *ngIf="to.description">{{ to.description }}</p>
+            <div class="alert alert-danger" role="alert" *ngIf="showError && formControl.errors">
+                <formly-validation-message [field]="field"></formly-validation-message>
+            </div>
+            <formly-field *ngFor="let f of field.fieldGroup" [field]="f"></formly-field>
+        </div>
+    `,
+})
+export class ObjectTypeComponent extends FieldType {
+    defaultOptions = {
+        defaultValue: {},
+    };
+}

--- a/ui/ui-editors/src/app/editor/_components/forms/definition-form.component.html
+++ b/ui/ui-editors/src/app/editor/_components/forms/definition-form.component.html
@@ -117,7 +117,7 @@
                 <definition-example-section [definition]="definition"></definition-example-section>
 
                 <!-- Vendor Extensions -->
-                <extensions-section [parent]="definition"></extensions-section>
+                <extensions-section [parent]="definition" [forComponent]="componentType"></extensions-section>
 
             </div>
         </div>

--- a/ui/ui-editors/src/app/editor/_components/forms/definition-form.component.ts
+++ b/ui/ui-editors/src/app/editor/_components/forms/definition-form.component.ts
@@ -48,6 +48,7 @@ import {EditorsService} from "../../_services/editors.service";
 import {RenameEntityDialogComponent, RenameEntityEvent} from "../dialogs/rename-entity.component";
 import {ApiCatalogService} from "../../_services/api-catalog.service";
 import {DropDownOption, DropDownOptionValue} from "../common/drop-down.component";
+import {ComponentType} from "../../_models/component-type.model";
 
 const INHERITANCE_TYPES: DropDownOption[] = [
     new DropDownOptionValue("No inheritance", "none"),
@@ -86,6 +87,8 @@ export class DefinitionFormComponent extends SourceFormComponent<OasSchema> {
 
     @ViewChild("cloneDefinitionDialog", { static: true }) cloneDefinitionDialog: CloneDefinitionDialogComponent;
     @ViewChild("renameDefinitionDialog", { static: true }) renameDefinitionDialog: RenameEntityDialogComponent;
+
+    readonly componentType: ComponentType = ComponentType.schema;
 
     /**
      * C'tor.
@@ -276,5 +279,4 @@ export class DefinitionFormComponent extends SourceFormComponent<OasSchema> {
         let hashIdx: number = this.definition.$ref.indexOf('#');
         return this.definition.$ref.substring(colonIdx + 1, hashIdx);
     }
-
 }

--- a/ui/ui-editors/src/app/editor/_components/forms/main-form.component.html
+++ b/ui/ui-editors/src/app/editor/_components/forms/main-form.component.html
@@ -51,6 +51,6 @@
     <security-requirements-section [parent]="document" [global]="true"></security-requirements-section>
 
     <!-- Vendor Extensions -->
-    <extensions-section [parent]="document"></extensions-section>
+    <extensions-section [parent]="document" [forComponent]="componentType"></extensions-section>
 
 </div>

--- a/ui/ui-editors/src/app/editor/_components/forms/main-form.component.ts
+++ b/ui/ui-editors/src/app/editor/_components/forms/main-form.component.ts
@@ -23,6 +23,7 @@ import {CommandService} from "../../_services/command.service";
 import {DocumentService} from "../../_services/document.service";
 import {ICommand} from "@apicurio/data-models";
 import {EditorsService} from "../../_services/editors.service";
+import {ComponentType} from "../../_models/component-type.model";
 
 
 @Component({
@@ -43,6 +44,8 @@ export class MainFormComponent extends SourceFormComponent<OasDocument> {
     get document(): OasDocument {
         return this._document;
     }
+
+    readonly componentType: ComponentType = ComponentType.document;
 
     public constructor(protected changeDetectorRef: ChangeDetectorRef,
                        protected selectionService: SelectionService,
@@ -71,5 +74,4 @@ export class MainFormComponent extends SourceFormComponent<OasDocument> {
         super.saveSource();
         this.sourceNode = this._document;
     }
-
 }

--- a/ui/ui-editors/src/app/editor/_components/forms/path-form.component.html
+++ b/ui/ui-editors/src/app/editor/_components/forms/path-form.component.html
@@ -101,7 +101,7 @@
                 <cookie-params-section [parent]="path" [path]="path" *ngIf="is3xDocument()"></cookie-params-section>
 
                 <!-- Vendor Extensions -->
-                <extensions-section [parent]="path"></extensions-section>
+                <extensions-section [parent]="path" [forComponent]="componentType"></extensions-section>
 
                 <!-- Operations Section -->
                 <operations-section [path]="path"></operations-section>

--- a/ui/ui-editors/src/app/editor/_components/forms/path-form.component.ts
+++ b/ui/ui-editors/src/app/editor/_components/forms/path-form.component.ts
@@ -45,6 +45,7 @@ import {DocumentService} from "../../_services/document.service";
 import {EditorsService} from "../../_services/editors.service";
 // import {SectionComponent} from "./shared/section.component";
 import {AbstractBaseComponent} from "../common/base-component";
+import {ComponentType} from "../../_models/component-type.model";
 
 
 @Component({
@@ -70,6 +71,8 @@ export class PathFormComponent extends SourceFormComponent<OasPathItem> {
     @ViewChild("clonePathDialog", { static: true }) clonePathDialog: ClonePathDialogComponent;
     @ViewChild("addPathDialog", { static: true }) addPathDialog: AddPathDialogComponent;
     @ViewChild("renamePathDialog", { static: true }) renamePathDialog: RenamePathDialogComponent;
+
+    readonly componentType: ComponentType = ComponentType.pathItem;
 
     public constructor(protected changeDetectorRef: ChangeDetectorRef,
                        protected selectionService: SelectionService,

--- a/ui/ui-editors/src/app/editor/_components/forms/path/operations-section.component.html
+++ b/ui/ui-editors/src/app/editor/_components/forms/path/operations-section.component.html
@@ -108,7 +108,7 @@
             <security-requirements-section [parent]="operation()" [global]="false"></security-requirements-section>
 
             <!-- Vendor Extensions -->
-            <extensions-section [parent]="operation()"></extensions-section>
+            <extensions-section [parent]="operation()" [forComponent]="componentType"></extensions-section>
 
         </div>
 

--- a/ui/ui-editors/src/app/editor/_components/forms/path/operations-section.component.ts
+++ b/ui/ui-editors/src/app/editor/_components/forms/path/operations-section.component.ts
@@ -38,6 +38,7 @@ import {ModelUtils} from "../../../_util/model.util";
 import {SelectionService} from "../../../_services/selection.service";
 import {AbstractBaseComponent} from "../../common/base-component";
 import {TopicSubscription} from "apicurio-ts-core";
+import {ComponentType} from "../../../_models/component-type.model";
 
 
 @Component({
@@ -58,6 +59,8 @@ export class OperationsSectionComponent extends AbstractBaseComponent {
     private _allOperations: OasOperation[] = [];
     private _collaborationPaths: string[] = [];
     private _selectionSubscription: TopicSubscription<string>;
+
+    readonly componentType: ComponentType = ComponentType.operation;
 
     /**
      * C'tor.

--- a/ui/ui-editors/src/app/editor/_components/forms/shared/extensions-section.component.html
+++ b/ui/ui-editors/src/app/editor/_components/forms/shared/extensions-section.component.html
@@ -25,7 +25,7 @@
         </div>
     </div>
 </section>
-<add-extension-dialog #addExtensionDialog (onAdd)="addExtension($event)"></add-extension-dialog>
+<add-extension-dialog #addExtensionDialog (onAdd)="addExtension($event)" [forComponent]="forComponent"></add-extension-dialog>
 <rename-entity-dialog #renameDialog
                       type="Extension"
                       title="Rename Vendor Extension"

--- a/ui/ui-editors/src/app/editor/_components/forms/shared/extensions-section.component.ts
+++ b/ui/ui-editors/src/app/editor/_components/forms/shared/extensions-section.component.ts
@@ -32,6 +32,7 @@ import {RenameEntityDialogComponent, RenameEntityEvent} from "../../dialogs/rena
 import {ObjectUtils} from "apicurio-ts-core";
 import {ModelUtils} from "../../../_util/model.util";
 import {AddExtensionDialogComponent} from "../../dialogs/add-extension.component";
+import {ComponentType} from "../../../_models/component-type.model";
 
 
 @Component({
@@ -43,6 +44,7 @@ import {AddExtensionDialogComponent} from "../../dialogs/add-extension.component
 export class ExtensionsSectionComponent extends AbstractBaseComponent {
 
     @Input() parent: ExtensibleNode;
+    @Input() forComponent: ComponentType;
 
     @ViewChild("addExtensionDialog", { static: true }) addExtensionDialog: AddExtensionDialogComponent;
     @ViewChild("renameDialog", { static: true }) renameDialog: RenameEntityDialogComponent;

--- a/ui/ui-editors/src/app/editor/_models/component-type.model.ts
+++ b/ui/ui-editors/src/app/editor/_models/component-type.model.ts
@@ -15,35 +15,20 @@
  * limitations under the License.
  */
 
-export function componentTypeToString(type: ComponentType): string {
-    switch (type) {
-        case ComponentType.schema:
-            return "schema";
-        case ComponentType.response:
-            return "response";
-        case ComponentType.parameter:
-            return "parameter";
-        case ComponentType.header:
-            return "header";
-        case ComponentType.requestBody:
-            return "requestBody";
-        case ComponentType.callback:
-            return "callback";
-        case ComponentType.example:
-            return "example";
-        case ComponentType.securityScheme:
-            return "securityScheme";
-        case ComponentType.link:
-            return "link";
-        case ComponentType.messageTrait:
-            return "messageTrait";
-        case ComponentType.message:
-            return "message";
-    }
-    return "n/a";
-}
-
 export enum ComponentType {
-    schema, response, parameter, header, requestBody, callback, example, securityScheme, link, messageTrait,
-    message,
+    schema = "schema",
+    response = "response",
+    parameter = "parameter",
+    header = "header",
+    requestBody = "requestBody",
+    callback = "callback",
+    example = "example",
+    securityScheme = "securityScheme",
+    link = "link",
+    info = "info",
+    messageTrait = "messageTrait",
+    message = "message",
+    document = "document",
+    pathItem = "pathItem",
+    operation = "operation"
 }

--- a/ui/ui-editors/src/app/editor/_models/features.model.ts
+++ b/ui/ui-editors/src/app/editor/_models/features.model.ts
@@ -19,6 +19,7 @@ export class VendorExtension {
     name: string;
     schema: any;
     model: any;
+    components: string[];
 }
 
 export class ApiEditorComponentFeatures {

--- a/ui/ui-editors/src/app/editor/_models/features.model.ts
+++ b/ui/ui-editors/src/app/editor/_models/features.model.ts
@@ -24,5 +24,5 @@ export class VendorExtension {
 export class ApiEditorComponentFeatures {
     validationSettings: boolean = false;
     componentImports: boolean = false;
-    vendorExtensions: VendorExtension[];
+    vendorExtensions?: VendorExtension[];
 }

--- a/ui/ui-editors/src/app/editor/_models/features.model.ts
+++ b/ui/ui-editors/src/app/editor/_models/features.model.ts
@@ -15,7 +15,14 @@
  * limitations under the License.
  */
 
+export class VendorExtension {
+    name: string;
+    schema: any;
+    model: any;
+}
+
 export class ApiEditorComponentFeatures {
     validationSettings: boolean = false;
     componentImports: boolean = false;
+    vendorExtensions: VendorExtension[];
 }

--- a/ui/ui-editors/src/app/models/editingInfo.model.ts
+++ b/ui/ui-editors/src/app/models/editingInfo.model.ts
@@ -16,10 +16,12 @@
  */
 import {EditingInfoContent} from "./editingInfoContent.model";
 import {EditingInfoFeatures} from "./editingInfoFeatures.model";
+import {EditingInfoOpenApi} from "./editingInfoOpenApi.model";
 
 export interface EditingInfo {
 
     content: EditingInfoContent;
     features: EditingInfoFeatures;
+    openapi: EditingInfoOpenApi;
 
 }

--- a/ui/ui-editors/src/app/models/editingInfoOpenApi.model.ts
+++ b/ui/ui-editors/src/app/models/editingInfoOpenApi.model.ts
@@ -2,6 +2,7 @@ interface EditingInfoOpenApiVendorExtension {
     name: string;
     schema: any;
     model: any;
+    components: string[];
 }
 
 export interface EditingInfoOpenApi {

--- a/ui/ui-editors/src/app/models/editingInfoOpenApi.model.ts
+++ b/ui/ui-editors/src/app/models/editingInfoOpenApi.model.ts
@@ -1,0 +1,11 @@
+interface EditingInfoOpenApiVendorExtension {
+    name: string;
+    schema: any;
+    model: any;
+}
+
+export interface EditingInfoOpenApi {
+
+    vendorExtensions: EditingInfoOpenApiVendorExtension[];
+
+}

--- a/ui/ui-editors/src/app/services/config.service.ts
+++ b/ui/ui-editors/src/app/services/config.service.ts
@@ -70,6 +70,7 @@ export class ConfigService {
     public get(): Promise<EditingInfo> {
         if (this.demoMode) {
             return new Promise((resolve, reject) => {
+                // TODO pass some vendor extensions for openapi editing
                 const info: EditingInfo = {
                     content: {
                         type: "OPENAPI",
@@ -78,6 +79,9 @@ export class ConfigService {
                     features: {
                         allowImports: false,
                         allowCustomValidations: false
+                    },
+                    openapi: {
+                        vendorExtensions: []
                     }
                 };
                 resolve(info);

--- a/ui/ui-editors/tsconfig.json
+++ b/ui/ui-editors/tsconfig.json
@@ -10,7 +10,7 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es2022",
     "module": "es2020",
     "lib": [
       "es2018",


### PR DESCRIPTION
It is now possible to configure Studio with a list of vendor extensions.  Each vendor extension has a name (e.g. `x-apicurio-address`), a JSON schema describing the format, a model with initial state, and an optional array of component types the extension applies to.  When configured, the OpenAPI editor will dynamically generate a form to create the value of the extension:

![image](https://github.com/Apicurio/apicurio-studio/assets/1890703/62288daa-dac4-4916-bb07-322598abdacc)
