### PR TITLE
fix(asyncapi): handle tags on operation and message based nodes

### DIFF
--- a/back-end/hub-core/src/test/resources/io/apicurio/hub/core/cmd/testExecuteCommands_Rename/__expected.json
+++ b/back-end/hub-core/src/test/resources/io/apicurio/hub/core/cmd/testExecuteCommands_Rename/__expected.json
@@ -195,21 +195,6 @@
     },
     "components": {
         "schemas": {
-            "AddressList": {
-                "properties": {
-                    "address": {
-                        "$ref": "#/components/schemas/Subtractress"
-                    }
-                }
-            },
-            "User": {
-                "properties": {
-                    "address": {
-                        "$ref": "#/components/schemas/Subtractress",
-                        "description": "Foo foo foo."
-                    }
-                }
-            },
             "Subtractress": {
                 "properties": {
                     "name": {
@@ -226,6 +211,21 @@
                     },
                     "zip": {
 
+                    }
+                }
+            },
+            "AddressList": {
+                "properties": {
+                    "address": {
+                        "$ref": "#/components/schemas/Subtractress"
+                    }
+                }
+            },
+            "User": {
+                "properties": {
+                    "address": {
+                        "$ref": "#/components/schemas/Subtractress",
+                        "description": "Foo foo foo."
                     }
                 }
             }

--- a/front-end/studio/package.json
+++ b/front-end/studio/package.json
@@ -49,7 +49,7 @@
     "@types/js-base64": "2.3.1",
     "@types/marked": "0.6.1",
     "@types/node": "15.14.0",
-    "@apicurio/data-models": "1.1.26",
+    "@apicurio/data-models": "1.1.28",
     "apicurio-ts-core": "0.1.3",
     "keycloak-js": "^16.1.1",
     "brace": "0.11.1",

--- a/front-end/studio/src/app/components/common/activity-item.component.ts
+++ b/front-end/studio/src/app/components/common/activity-item.component.ts
@@ -499,6 +499,9 @@ export class ActivityItemComponent {
             case "DeleteAllTagsCommand":
                 rval = "deleted all of the tags from the API.";
                 break;
+            case "DeleteAllTagsCommand_Aai20":
+                rval = "deleted all of the tags at location " +  this.command()["_nodePath"] + ".";
+                break;
             case "DeleteAllServersCommand":
                 ppath = this.command()["_parentPath"];
                 if (ppath == "/") {
@@ -594,7 +597,7 @@ export class ActivityItemComponent {
                 rval = "deleted the global Tag definition with name '" + this.command()["_tagName"] + "'.";
                 break;
             case "DeleteTagCommand_Aai20":
-                rval = "deleted Tag definition with name '" + this.command()["_tagName"] + "' at location '" + this.command()["_nodePath"] + "'.";
+                rval = "deleted Tag definition with name '" + this.command()["_tagName"] + "' at location " + this.command()["_nodePath"] + ".";
                 break;
             case "DeleteRequestBodyCommand_30":
                 rval = "deleted the global Tag definition with name '" + this.command()["_tagName"] + "'.";
@@ -686,7 +689,7 @@ export class ActivityItemComponent {
                 rval = "added a new Tag named '" + this.command()["_tagName"] + "'.";
                 break;
             case "NewTagCommand_Aai20":
-                rval = "added a new Tag named '" + this.command()["_tagName"] + "' at location '" + this.command()["_nodePath"] + "'.";
+                rval = "added a new Tag named '" + this.command()["_tagName"] + "' at location " + this.command()["_nodePath"] + ".";
                 break;
             case "ReplaceOperationCommand":
             case "ReplaceOperationCommand_20":

--- a/front-end/studio/src/app/components/common/activity-item.component.ts
+++ b/front-end/studio/src/app/components/common/activity-item.component.ts
@@ -220,6 +220,7 @@ export class ActivityItemComponent {
             case "DeleteTagCommand":
             case "DeleteTagCommand_20":
             case "DeleteTagCommand_30":
+            case "DeleteTagCommand_Aai20":
             case "DeleteRequestBodyCommand_30":
             case "DeleteAllResponsesCommand":
             case "DeleteAllResponsesCommand_20":
@@ -294,6 +295,7 @@ export class ActivityItemComponent {
             case "NewTagCommand":
             case "NewTagCommand_20":
             case "NewTagCommand_30":
+            case "NewTagCommand_Aai20":
                 rval = "tag";
                 break;
             case "ReplaceOperationCommand":
@@ -591,6 +593,9 @@ export class ActivityItemComponent {
             case "DeleteTagCommand_30":
                 rval = "deleted the global Tag definition with name '" + this.command()["_tagName"] + "'.";
                 break;
+            case "DeleteTagCommand_Aai20":
+                rval = "deleted Tag definition with name '" + this.command()["_tagName"] + "' at location '" + this.command()["_nodePath"] + "'.";
+                break;
             case "DeleteRequestBodyCommand_30":
                 rval = "deleted the global Tag definition with name '" + this.command()["_tagName"] + "'.";
                 break;
@@ -679,6 +684,9 @@ export class ActivityItemComponent {
             case "NewTagCommand_20":
             case "NewTagCommand_30":
                 rval = "added a new Tag named '" + this.command()["_tagName"] + "'.";
+                break;
+            case "NewTagCommand_Aai20":
+                rval = "added a new Tag named '" + this.command()["_tagName"] + "' at location '" + this.command()["_nodePath"] + "'.";
                 break;
             case "ReplaceOperationCommand":
             case "ReplaceOperationCommand_20":

--- a/front-end/studio/src/app/components/common/activity-item.component.ts
+++ b/front-end/studio/src/app/components/common/activity-item.component.ts
@@ -183,6 +183,7 @@ export class ActivityItemComponent {
             case "DeleteAllPropertiesCommand_20":
             case "DeleteAllPropertiesCommand_30":
             case "DeleteAllTagsCommand":
+            case "DeleteAllTagsCommand_Aai20":
             case "DeleteAllServersCommand":
             case "DeleteAllSecurityRequirementsCommand":
             case "DeleteAllSecuritySchemesCommand":

--- a/front-end/studio/src/app/editor.module.ts
+++ b/front-end/studio/src/app/editor.module.ts
@@ -168,6 +168,8 @@ import {JsonSummaryComponent} from "./components/common/json-summary.component";
 import {InlineJsonEditorComponent} from "./pages/apis/{apiId}/editor/_components/common/inline-json-editor.component";
 import {AddExtensionDialogComponent} from "./pages/apis/{apiId}/editor/_components/dialogs/add-extension.component";
 import {ReferencePropertiesSectionComponent} from "./pages/apis/{apiId}/editor/_components/forms/definition/reference-properties-section.component";
+import {AaitagsSectionComponent} from "./pages/apis/{apiId}/editor/_components/forms/channel/operation/aaitags-section.component";
+import {AaiAddTagDialogComponent} from "./pages/apis/{apiId}/editor/_components/dialogs/aaiadd-tag.component";
 
 @NgModule({
     imports: [
@@ -202,7 +204,7 @@ import {ReferencePropertiesSectionComponent} from "./pages/apis/{apiId}/editor/_
         ResponseEditorComponent, MessageTraitEditorComponent, MessageEditorComponent, OneOfInMessageEditorComponent, ResponseFormComponent, CloneResponseDefinitionDialogComponent,
         AsyncApiEditorComponent, GraphQLEditorComponent, PropertiesSectionComponent, InheritanceSchemasSectionComponent,
         SchemaRowComponent, AddSchemaDialogComponent, CloneChannelDialogComponent, ExtensionsSectionComponent,
-        ExtensionRowComponent, JsonSummaryComponent, InlineJsonEditorComponent, AddExtensionDialogComponent
+        ExtensionRowComponent, JsonSummaryComponent, InlineJsonEditorComponent, AddExtensionDialogComponent, AaitagsSectionComponent, AaiAddTagDialogComponent
     ],
     providers: [
         ProblemsService, SelectionService, LicenseService, CommandService, DocumentService, EditorsService,

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/aaiadd-tag.component.css
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/aaiadd-tag.component.css
@@ -1,0 +1,29 @@
+#addTagModal .modal-dialog .modal-body form textarea {
+    min-height: 60px;
+}
+
+#addtag-form .apriori-items {
+    margin-top: 4px;
+}
+
+#addtag-form .apriori-items .apriori-item {
+    background-color: #9c9c9c;
+    color: white;
+    cursor: pointer;
+    margin-right: 5px;
+    padding: 3px 6px;
+    margin-bottom: 3px;
+    display: inline-block;
+}
+
+#addtag-form .apriori-items .apriori-item.selected {
+    background-color: #39a5dc;
+}
+
+#addtag-form .apriori-items .apriori-item:hover {
+    filter: brightness(90%);
+}
+
+#addtag-form .apriori-items .apriori-item > .fa {
+    margin-right: 3px;
+}

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/aaiadd-tag.component.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/aaiadd-tag.component.html
@@ -1,0 +1,47 @@
+<!-- Add Tag Dialog -->
+<div bsModal #addTagModal="bs-modal" class="modal fade" id="addTagModal" tabindex="-1" role="dialog" aria-labelledby="addTagModalLabel"
+     role="dialog" aria-hidden="true" (onShown)="doSelect()" [config]="{ backdrop: true }"
+     (onHidden)="close()" *ngIf="isOpen()">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" aria-hidden="true" (click)="cancel()">
+                    <span class="pficon pficon-close"></span>
+                </button>
+                <h4 class="modal-title" id="addTagModalLabel">Add Tag</h4>
+            </div>
+            <div class="modal-body">
+                <p>Enter information about the new tag below and then click <strong>Add</strong>.</p>
+                <form id="addtag-form" class="form-horizontal" (submit)="add()" #addTagForm="ngForm" data-dismiss="modal">
+                    <div class="form-group">
+                        <label class="col-sm-2 control-label required" for="tag">Tag</label>
+                        <div class="col-sm-10">
+                            <input #addTagInput name="tag" type="text" id="tag" class="form-control" placeholder="Tag Name"
+                                   required [(ngModel)]="tag" (ngModelChange)="tagExists = tags.indexOf($event) != -1" #name="ngModel">
+                            <div class="apriori-items" *ngIf="hasItems()">
+                                <span class="apriori-item" *ngFor="let item of getItems()" (click)="toggleItem(item)" [class.selected]="hasItem(item)">
+                                    <span class="fa fa-square-o" *ngIf="!hasItem(item)"></span>
+                                    <span class="fa fa-check-square-o" *ngIf="hasItem(item)"></span>
+                                    <span>{{ item }}</span>
+                                </span>
+                            </div>
+                        </div>
+
+                    </div>
+                    <div class="form-group">
+                        <label class="col-sm-2 control-label" for="description">Description</label>
+                        <div class="col-sm-10">
+                            <textarea name="description" id="description" class="form-control" autosize
+                                      placeholder="Tag description" [(ngModel)]="description"></textarea>
+                        </div>
+                    </div>
+                </form>
+            </div>
+            <div class="notice-of-required modal-notice-of-required">The fields marked with <span class="required-icon">*</span> are required.</div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-primary" (click)="add()" [disabled]="!addTagForm.form.valid || tagExists">Add</button>
+                <button type="button" class="btn btn-default" (click)="cancel()">Cancel</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/aaiadd-tag.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/aaiadd-tag.component.ts
@@ -1,0 +1,140 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Component, ElementRef, EventEmitter, Output, QueryList, ViewChildren} from "@angular/core";
+import {ModalDirective} from "ngx-bootstrap/modal";
+import {AaiMessageBase, AaiOperation, AaiOperationBase, Node, OasDocument} from "@apicurio/data-models";
+
+
+@Component({
+    selector: "aaiadd-tag-dialog",
+    templateUrl: "aaiadd-tag.component.html",
+    styleUrls: ["aaiadd-tag.component.css"]
+})
+export class AaiAddTagDialogComponent {
+
+    @Output() onAdd: EventEmitter<any> = new EventEmitter<any>();
+
+    @ViewChildren("addTagModal") addTagModal: QueryList<ModalDirective>;
+    @ViewChildren("addTagInput") addTagInput: QueryList<ElementRef>;
+
+    private _isOpen: boolean = false;
+    private _node: Node;
+
+    tag: string = "";
+    description: string = "";
+
+    tags: string[] = [];
+    tagExists: boolean = false;
+
+    /**
+     * Called to open the dialog.
+     */
+    public open(node: AaiOperationBase | AaiMessageBase, tag?: string): void {
+        this._node = node;
+        this.tag = tag;
+        if (!tag) {
+            this.tag = "";
+        }
+        this._isOpen = true;
+        this.addTagModal.changes.subscribe( () => {
+            if (this.addTagModal.first) {
+                this.addTagModal.first.show();
+            }
+        });
+
+        this.tags = [];
+        this.tagExists = false;
+        
+        
+        if (node.tags) {
+            node.tags.forEach(tag => {
+                this.tags.push(tag.name);
+            });
+        }
+    }
+
+    /**
+     * Called to close the dialog.
+     */
+    close(): void {
+        this._isOpen = false;
+        this.tag = "";
+        this.description = "";
+    }
+
+    /**
+     * Called when the user clicks "add".
+     */
+    add(): void {
+        let tagInfo: any = {
+            name: this.tag,
+            description: this.description
+        };
+        this.onAdd.emit(tagInfo);
+        this.cancel();
+    }
+
+    /**
+     * Called when the user clicks "cancel".
+     */
+    cancel(): void {
+        this.addTagModal.first.hide();
+    }
+
+    /**
+     * Returns true if the dialog is open.
+     * @return
+     */
+    isOpen(): boolean {
+        return this._isOpen;
+    }
+
+    /**
+     * Called to initialize the selection/focus to the addTagInput field.
+     */
+    doSelect(): void {
+        this.addTagInput.first.nativeElement.focus();
+    }
+
+    public getItems(): string[] {
+        if (this._node.ownerDocument().tags && this._node.ownerDocument().tags.length > 0) {
+            let items: string[] = this._node.ownerDocument().tags.map(tagDef => tagDef.name).filter(tagName => !this.tags.includes(tagName));
+            items.sort();
+            return items;
+        } else {
+            return [];
+        }
+    }
+    
+    public hasItems(): boolean {
+        return this.getItems().length > 0;
+    }
+
+    public hasItem(item: string): boolean {
+        return this.tag && this.tag === item;
+    }
+    
+    public toggleItem(item: string) {
+        if (this.hasItem(item)) {
+            this.tag = null;
+        } else {
+            this.tag = item;
+        }
+    }
+
+}

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/aaimain-form.component.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/aaimain-form.component.html
@@ -32,7 +32,7 @@
     <!-- License -->
     <aailicense-section [document]="document"></aailicense-section>
 
-    <tags-section [document]="document"></tags-section>
+    <tags-section [document]="document" [enableRename]="false"></tags-section>
 
     <!-- Global Servers -->
     <aaiservers-section [parent]="document" [collapsed]="false"

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/channel/operation/aaitags-section.component.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/channel/operation/aaitags-section.component.html
@@ -1,0 +1,26 @@
+<section type="tags" label="TAG DEFINITIONS" [counterItems]="tags()"
+         contextHelp="Configure tags for your API in this section.  Once defined, tags can be used to organize your API's operations by arbitrary criteria."
+         collaborationNodePath="/tags"
+         [validationModels]="tags()">
+    <span actions>
+        <icon-button (onClick)="addTagDialog.open(node)" [pullRight]="true" type="add"
+                     title="Add a tag to the API."></icon-button>
+        <icon-button (onClick)="deleteAllTags()" [disabled]="!hasTags()"
+                     [pullRight]="true" type="delete"
+                     title="Delete all tag definitions."></icon-button>
+    </span>
+    <div body>
+        <signpost *ngIf="tags().length === 0">
+            <span>No tags have been configured.</span>
+            <a (click)="addTagDialog.open(node)">Add a tag</a>
+        </signpost>
+
+        <!-- The list of tags -->
+        <div class="tags" *ngIf="tags().length > 0">
+            <tag-row *ngFor="let tag of tags()" [item]="tag"
+                     (onDelete)="deleteTag(tag)" [enableRename]="false"></tag-row>
+        </div>
+    </div>
+</section>
+<aaiadd-tag-dialog #addTagDialog (onAdd)="addTag($event)"></aaiadd-tag-dialog>
+

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/channel/operation/aaitags-section.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/channel/operation/aaitags-section.component.ts
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * Copyright 2017 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
+    Component,
+    Input,
+    ViewEncapsulation
+} from "@angular/core";
+import {
+    AaiOperationBase,
+    AaiMessageBase,
+    CommandFactory,
+    ICommand,
+    Library,
+    OasTag,
+} from "@apicurio/data-models";
+import {CommandService} from "../../../../_services/command.service";
+import {AbstractBaseComponent} from "../../../common/base-component";
+import {DocumentService} from "../../../../_services/document.service";
+import {SelectionService} from "../../../../_services/selection.service";
+import {ObjectUtils} from "apicurio-ts-core";
+
+
+@Component({
+    selector: "aaitags-section",
+    templateUrl: "aaitags-section.component.html",
+    encapsulation: ViewEncapsulation.None,
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class AaitagsSectionComponent extends AbstractBaseComponent {
+
+    @Input() node: AaiOperationBase | AaiMessageBase;
+
+    /**
+     * C'tor.
+     * @param changeDetectorRef
+     * @param documentService
+     * @param commandService
+     * @param selectionService
+     */
+    constructor(private changeDetectorRef: ChangeDetectorRef, private documentService: DocumentService,
+                private commandService: CommandService, private selectionService: SelectionService) {
+        super(changeDetectorRef, documentService, selectionService);
+    }
+
+    /**
+     * Returns the list of tags defined in the document.
+     * @return
+     */
+    public tags(): OasTag[] {
+        let tags: OasTag[] = this.node.tags;
+        if (ObjectUtils.isNullOrUndefined(tags)) {
+            tags = [];
+        }
+        // Clone the array
+        tags = tags.slice(0);
+        // Sort it
+        tags.sort( (obj1, obj2) => {
+            return obj1.name.toLowerCase().localeCompare(obj2.name.toLowerCase());
+        });
+        return tags;
+    }
+
+    /**
+     * Called when the user changes the description of a tag.
+     * @param tag
+     * @param description
+     */
+    public changeTagDescription(tag: OasTag, description: string): void {
+        let command: ICommand = CommandFactory.createChangePropertyCommand<string>(tag, "description", description);
+        this.commandService.emit(command);
+    }
+
+    /**
+     * Called when the user chooses to delete a tag.
+     * @param tag
+     */
+    public deleteTag(tag: OasTag): void {
+        let command: ICommand = CommandFactory.createDeleteTagCommand_Aai20(tag.name, this.node);
+        this.commandService.emit(command);
+    }
+
+    /**
+     * Called when the user clicks 'Add' on the Add Tag modal dialog.
+     * @param tag
+     */
+    public addTag(tag: any): void {
+        let command: ICommand = CommandFactory.createNewTagCommand_Aai20(tag.name, tag.description, this.node);
+        this.commandService.emit(command);
+        let path = Library.createNodePath(this.node);
+        path.appendSegment("tags", false);
+        this.selectionService.select(path.toString());
+    }
+
+    /**
+     * Returns true if the document has at least one tag defined.
+     */
+    public hasTags(): boolean {
+        return this.node.tags && this.node.tags.length > 0;
+    }
+
+    /**
+     * Called when the user clicks the trash icon to delete all the tags.
+     */
+    public deleteAllTags(): void {
+        let command: ICommand = CommandFactory.createDeleteAllTagsCommand_Aai20(this.node);
+        this.commandService.emit(command);
+    }
+}

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/channel/operation/info-section.component.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/channel/operation/info-section.component.html
@@ -54,9 +54,7 @@
             <span>Tags</span>
         </div>
         <div class="section-field tags">
-            <inline-array-editor noValueMessage="No tags configured." [value]="operation.tags" [items]="tagDefs()"
-                                 [baseNode]="operation" nodepath="tags"
-                                 (onChange)="changeTags($event)"></inline-array-editor>
+            <aaitags-section [node]="operation"></aaitags-section>
         </div>
     </div>
 </section>

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/channel/operation/info-section.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/channel/operation/info-section.component.ts
@@ -47,7 +47,7 @@ export class ChannelOperationInfoSectionComponent extends AbstractBaseComponent 
     @Input() operation: AaiOperation;
 
     private _operationInfoPaths: string[];
-
+    
     /**
      * C'tor.
      * @param changeDetectorRef
@@ -106,27 +106,5 @@ export class ChannelOperationInfoSectionComponent extends AbstractBaseComponent 
         console.info("[ChannelOperationInfoSectionComponent] User changed the operationId.");
         let command: ICommand = CommandFactory.createChangePropertyCommand(this.operation, "operationId", newOperationId);
         this.commandService.emit(command);
-    }
-
-    /**
-     * Called when the user changes the tags.
-     * @param newTags
-     */
-    public changeTags(newTags: string[]): void {
-        console.info("[ChannelOperationInfoSectionComponent] User changed the tags.");
-        let command: ICommand = CommandFactory.createChangePropertyCommand(this.operation, "tags", newTags);
-        this.commandService.emit(command);
-    }
-
-    public tagDefs(): ()=>string[] {
-        return ()=> {
-            if (this.operation.ownerDocument().tags && this.operation.ownerDocument().tags.length > 0) {
-                let tagDefs: string[] = this.operation.ownerDocument().tags.map(tagDef => tagDef.name);
-                tagDefs.sort();
-                return tagDefs;
-            } else {
-                return [];
-            }
-        }
     }
 }

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/main/tag-row.component.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/main/tag-row.component.html
@@ -18,7 +18,7 @@
                     <span class="fa fa-ellipsis-v"></span>
                 </button>
                 <ul class="dropdown-menu dropdown-menu-right">
-                    <li><a (click)="renameTag()"><span class="fa fa-fw fa-pencil-square-o"></span><span>Rename</span></a></li>
+                    <li *ngIf="enableRename"><a (click)="renameTag()"><span class="fa fa-fw fa-pencil-square-o"></span><span>Rename</span></a></li>
                     <li role="separator" class="divider"></li>
                     <li><a (click)="delete()"><span class="fa fa-fw fa-trash"></span><span>Delete</span></a></li>
                 </ul>

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/main/tag-row.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/main/tag-row.component.ts
@@ -20,6 +20,7 @@ import {
     ChangeDetectorRef,
     Component,
     EventEmitter,
+    Input,
     Output,
     ViewEncapsulation
 } from "@angular/core";
@@ -41,6 +42,7 @@ export class TagRowComponent extends AbstractRowComponent<OasTag, string> {
 
     @Output() onDelete: EventEmitter<void> = new EventEmitter<void>();
     @Output() onRename: EventEmitter<void> = new EventEmitter<void>();
+    @Input() enableRename: boolean = true
 
     /**
      * C'tor.

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/main/tags-section.component.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/main/tags-section.component.html
@@ -18,6 +18,7 @@
         <!-- The list of tags -->
         <div class="tags" *ngIf="tags().length > 0">
             <tag-row *ngFor="let tag of tags()" [item]="tag"
+                     [enableRename]="enableRename"
                      (onRename)="openRenameDialog(tag)"
                      (onDelete)="deleteTag(tag)"></tag-row>
         </div>

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/main/tags-section.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/main/tags-section.component.ts
@@ -50,6 +50,7 @@ import {ObjectUtils} from "apicurio-ts-core";
 export class TagsSectionComponent extends AbstractBaseComponent {
 
     @Input() document: OasDocument;
+    @Input() enableRename: boolean = true;
 
     @ViewChild("renameDialog", { static: true }) renameDialog: RenameEntityDialogComponent;
 

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/message-form.component.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/message-form.component.html
@@ -156,7 +156,9 @@
                     <headers-tab [message]="message" *ngIf="isPartActive('headers')"></headers-tab>
                 </div>
 
-
+                <div class="section-field tags">
+                    <aaitags-section [node]="message"></aaitags-section>
+                </div>
             </div>
         </div>
     </div>

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/messagetrait-form.component.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/messagetrait-form.component.html
@@ -83,9 +83,7 @@
                     <span>Tags</span>
                 </div>
                 <div class="section-field tags">
-                    <inline-array-editor noValueMessage="No tags configured." [value]="messageTrait.tags" [items]="tagDefs()"
-                                        [baseNode]="messageTrait" nodepath="tags"
-                                        (onChange)="changeTags($event)"></inline-array-editor>
+                    <aaitags-section [node]="messageTrait"></aaitags-section>
                 </div>
             </div>
         </div>

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/messagetrait-form.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/messagetrait-form.component.ts
@@ -113,22 +113,4 @@ export class MessageTraitFormComponent extends SourceFormComponent<AaiMessageTra
                 "description", newDescription);
         this.commandService.emit(command);
     }
-
-    public changeTags(newTags: string[]): void {
-        console.info("[MessageTraitFormComponent] User changed the tags.");
-        let command: ICommand = CommandFactory.createChangePropertyCommand(this.messageTrait, "tags", newTags);
-        this.commandService.emit(command);
-    }
-
-    public tagDefs(): ()=>string[] {
-        return ()=> {
-            if (this.messageTrait.ownerDocument().tags && this.messageTrait.ownerDocument().tags.length > 0) {
-                let tagDefs: string[] = this.messageTrait.ownerDocument().tags.map(tagDef => tagDef.name);
-                tagDefs.sort();
-                return tagDefs;
-            } else {
-                return [];
-            }
-        }
-    }
 }

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/operationtrait-form.component.html
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/operationtrait-form.component.html
@@ -70,9 +70,7 @@
                     <span>Tags</span>
                 </div>
                 <div class="section-field tags">
-                    <inline-array-editor noValueMessage="No tags configured." [value]="operationTrait.tags" [items]="tagDefs()"
-                                        [baseNode]="operationTrait" nodepath="tags"
-                                        (onChange)="changeTags($event)"></inline-array-editor>
+                    <aaitags-section [node]="operationTrait"></aaitags-section>
                 </div>
             </div>
         </div>

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/operationtrait-form.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/forms/operationtrait-form.component.ts
@@ -106,22 +106,4 @@ export class OperationTraitFormComponent extends SourceFormComponent<AaiOperatio
                 "description", newDescription);
         this.commandService.emit(command);
     }
-
-    public changeTags(newTags: string[]): void {
-        console.info("[OperationTraitFormComponent] User changed the tags.");
-        let command: ICommand = CommandFactory.createChangePropertyCommand(this.operationTrait, "tags", newTags);
-        this.commandService.emit(command);
-    }
-
-    public tagDefs(): ()=>string[] {
-        return ()=> {
-            if (this.operationTrait.ownerDocument().tags && this.operationTrait.ownerDocument().tags.length > 0) {
-                let tagDefs: string[] = this.operationTrait.ownerDocument().tags.map(tagDef => tagDef.name);
-                tagDefs.sort();
-                return tagDefs;
-            } else {
-                return [];
-            }
-        }
-    }
 }

--- a/front-end/studio/yarn.lock
+++ b/front-end/studio/yarn.lock
@@ -249,12 +249,12 @@
   dependencies:
     tslib "^2.0.0"
 
-"@apicurio/data-models@1.1.26":
-  version "1.1.26"
-  resolved "https://registry.yarnpkg.com/@apicurio/data-models/-/data-models-1.1.26.tgz#b6ed0d17c0563b50ab76c9f763f37f41ebc7341d"
-  integrity sha512-/HDzu8NTzKGpZg5ULiuPhKRC5DuSplFtbSNonxP7tdwsowQRM+IL7xp2CX1+HSh6iO4momfIwcFmvbahOM3/Rg==
+"@apicurio/data-models@1.1.28":
+  version "1.1.28"
+  resolved "https://artifactory.s.arkea.com/artifactory/api/npm/npm/@apicurio/data-models/-/data-models-1.1.28.tgz#49a7a768b1bd49b345b04ffafbdc097d1ea95979"
+  integrity sha512-k7NCgYvRD+uNY9BkGm451wBIhdIiNUQoTHkZ1VZHyJB3Q9QSna5Z5Nl05rEKS723x6X9MSAvu6p21hy6DA3Axw==
   dependencies:
-    core-js "3.21.1"
+    core-js "3.27.2"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.14.5":
   version "7.14.5"
@@ -3213,10 +3213,10 @@ core-js@2.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
   integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
 
-core-js@3.21.1:
-  version "3.21.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.21.1.tgz#f2e0ddc1fc43da6f904706e8e955bc19d06a0d94"
-  integrity sha512-FRq5b/VMrWlrmCzwRrpDYNxyHP9BcAZC+xHJaqTgIE5091ZV1NTmyh0sGOg5XqpnHvR0svdy0sv1gWA1zmhxig==
+core-js@3.27.2:
+  version "3.27.2"
+  resolved "https://artifactory.s.arkea.com/artifactory/api/npm/npm/core-js/-/core-js-3.27.2.tgz#85b35453a424abdcacb97474797815f4d62ebbf7"
+  integrity sha512-9ashVQskuh5AZEZ1JdQWp1GqSoC1e1G87MzRqg2gIfVAQ7Qn9K+uFj8EcniUFA4P2NLZfV+TOlX1SzoKfo+s7w==
 
 core-js@3.8.3:
   version "3.8.3"

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <version.io.quarkus>2.16.4.Final</version.io.quarkus>
 
         <!-- Other Apicurio Projects -->
-        <version.apicurio-data-models>1.1.26</version.apicurio-data-models>
+        <version.apicurio-data-models>1.1.28</version.apicurio-data-models>
         <version.apicurio-registry>1.3.2.Final</version.apicurio-registry>
         <version.apicurio-codegen>1.0.14.Final</version.apicurio-codegen>
 


### PR DESCRIPTION
fixes #2752

As part of this PR there is also :
* adds tag selection on message nodes
* tag renaming is disabled on all asyncapi nodes. For children nodes it's the same on openapi since inline-array-editor can only add or delete tag. For root node it would require an asyncapi specific RenameTagDefinitionCommand to handle hierarchical renaming on message based and operation based nodes that is not yet available.