### PR TITLE
fix: generate example wrongly returns array of examples

### DIFF
--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_util/model.util.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_util/model.util.ts
@@ -116,12 +116,11 @@ export class ModelUtils {
      */
     public static generateExampleFromSchema(schema: OasSchema | AaiSchema): any {
         let generator: ExampleGenerator = new ExampleGenerator();
-        let example : any[] = [];
-        example.push(generator.generate(schema));
+        let example = generator.generate(schema);
         if (schema.allOf) {
-            schema.allOf.forEach( inherited => {
+            schema.allOf.forEach(inherited => {
                 if (inherited.$ref) {
-                    example.push(generator.generate(inherited));
+                    Object.assign(example, generator.generate(inherited));
                 }
             });
         }


### PR DESCRIPTION
# Issue

Because of an error in a previous commit to handle allOf, generate example functionality always returns an array even for simple models. This fix returns a simple object as expected by openapi specs and merges models in one object in case of allOf inheritance.

# How to test

For simple types: 

1. Open an openapi spec and edit a data type
2. Add a property "age" of type number
3. Click "generate" button in example text area
4. Current result:
```json
[
    {
        "age": 7
    }
]
```
Expected result:
```json
{
   "age": 7
}
```

With allOf inheritance:

1. Select allOf inheritance type in previous data type
2. add a schema with one property "id" of type number
3. Click "generate" button in example text area
4. Current result:
```json
[
    {
        "age": 7
    },
   {
        "id": 1
   }
]
```
Expected result:
```json
{
   "age": 7,
   "id": 1
}
```

