### PR TITLE
fix(asyncapi): broken schema inheritance

### DIFF
--- a/front-end/studio/package.json
+++ b/front-end/studio/package.json
@@ -18,7 +18,7 @@
   "private": false,
   "peerDependencies": {
     "@patternfly/patternfly": "1.0.250",
-    "@apicurio/data-models": "1.1.26",
+    "@apicurio/data-models": "1.1.30",
     "apicurio-ts-core": "0.1.3",
     "keycloak-js": "^16.1.1",
     "brace": "0.11.1",
@@ -49,7 +49,7 @@
     "@types/js-base64": "2.3.1",
     "@types/marked": "0.6.1",
     "@types/node": "15.14.0",
-    "@apicurio/data-models": "1.1.28",
+    "@apicurio/data-models": "1.1.30",
     "apicurio-ts-core": "0.1.3",
     "keycloak-js": "^16.1.1",
     "brace": "0.11.1",

--- a/front-end/studio/src/app/components/common/activity-item.component.ts
+++ b/front-end/studio/src/app/components/common/activity-item.component.ts
@@ -110,6 +110,7 @@ export class ActivityItemComponent {
             case "AddParameterExampleCommand_30":
             case "AddChannelItemCommand":
             case "AddChildSchemaCommand":
+            case "AddChildSchemaCommand_Aai20":
             case "AddMessageExampleCommand_Aai20":
             case "AddOneOfInMessageCommand":
             case "AddResponseDefinitionCommand":
@@ -147,6 +148,7 @@ export class ActivityItemComponent {
             case "ChangeResponseTypeCommand":
             case "ChangeResponseTypeCommand_20":
             case "ChangeSchemaTypeCommand":
+            case "ChangeSchemaTypeCommand_Aai20":
             case "ChangeResponseDefinitionTypeCommand":
             case "ChangeResponseDefinitionTypeCommand_20":
             case "ChangePayloadRefCommand_Aai20":
@@ -155,6 +157,8 @@ export class ActivityItemComponent {
             case "ChangePropertyCommand":
             case "ChangePropertyCommand_20":
             case "ChangePropertyCommand_30":
+            case "ChangeSchemaInheritanceCommand":
+            case "ChangeSchemaInheritanceCommand_Aai20":
             case "ChangeSecuritySchemeCommand":
             case "ChangeSecuritySchemeCommand_20":
             case "ChangeSecuritySchemeCommand_30":
@@ -189,6 +193,7 @@ export class ActivityItemComponent {
             case "DeleteAllSecurityRequirementsCommand":
             case "DeleteAllSecuritySchemesCommand":
             case "DeleteAllChildSchemasCommand":
+            case "DeleteAllChildSchemasCommand_Aai20":
             case "DeleteAllExamplesCommand":
             case "DeleteAllMessageExamplesCommand_Aai20":
             case "DeleteAllOperationsCommand_Aai20":
@@ -240,6 +245,7 @@ export class ActivityItemComponent {
             case "DeleteExtensionCommand":
             case "DeleteChannelCommand":
             case "DeleteChildSchemaCommand":
+            case "DeleteChildSchemaCommand_Aai20":
             case "DeleteMessageDefinitionCommand":
             case "DeleteMessageExampleCommand_Aai20":
             case "DeleteMessageTraitDefinitionCommand":
@@ -400,6 +406,10 @@ export class ActivityItemComponent {
             case "AddChannelItemCommand":
                 rval = "added a Channel Item named " + this.command()["_newChannelItemName"] + ".";
                 break;
+            case "AddChildSchemaCommand":
+            case "AddChildSchemaCommand_Aai20":
+                rval = "added child schema to schema from path '" + this.command()["_schemaPath"] + "'";
+                break;
             case "AddPathItemCommand":
             case "AddPathItemCommand_20":
             case "AddPathItemCommand_30":
@@ -456,6 +466,10 @@ export class ActivityItemComponent {
             case "ChangePropertyTypeCommand_30":
                 rval = "changed the type of the Schema Property named '" + this.command()["_propName"] + "' at location " + this.command()["_propPath"] + ".";
                 break;
+            case "ChangeSchemaInheritanceCommand":
+            case "ChangeSchemaInheritanceCommand_Aai20":
+                rval = "changed the type of the Schema inheritance at location " + this.command()["_schemaPath"] + ".";
+                break;
             case "ChangeSchemaTypeCommand":
                 rval = "changed the type of the Schema at location " + this.command()["_schemaPath"] + ".";
                 break;
@@ -494,6 +508,10 @@ export class ActivityItemComponent {
             case "ChangeVersionCommand_20":
             case "ChangeVersionCommand_30":
                 rval = "altered the API's version to '" + this.command()["_newVersion"] + "'";
+                break;
+            case "DeleteAllChildSchemasCommand":
+            case "DeleteAllChildSchemasCommand_Aai20":
+                rval = "deleted all inherited schemas of the schema from path '" + this.command()["_schemaPath"] + "'";
                 break;
             case "DeleteAllOperationsCommand":
                 rval = "deleted all of the operations from path " + this.command()["_parentPath"] + ".";
@@ -544,6 +562,10 @@ export class ActivityItemComponent {
                 break;
             case "DeleteMediaTypeCommand":
                 rval = "deleted Media Type '" + this.command()["_mediaTypeName"] + "' at location " + this.command()["_mediaTypePath"] + ".";
+                break;
+            case "DeleteChildSchemaCommand":
+            case "DeleteChildSchemaCommand_Aai20":
+                rval = "deleted child schema to schema from path '" + this.command()["_schemaPath"] + "'";
                 break;
             case "DeleteOneOfMessageCommand":
                 rval = "deleted Message from component/operation'" + JSON.stringify(this.command()["_oldMessage"]) + ".";

--- a/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/add-schema.component.ts
+++ b/front-end/studio/src/app/pages/apis/{apiId}/editor/_components/dialogs/add-schema.component.ts
@@ -17,7 +17,7 @@
 
 import {Component, EventEmitter, Output, QueryList, ViewChildren} from "@angular/core";
 import {ModalDirective} from "ngx-bootstrap/modal";
-import {Library, Document, TraverserDirection, OasDocument} from "@apicurio/data-models";
+import {Document, DocumentType, Library, OasDocument, TraverserDirection} from "@apicurio/data-models";
 import {DropDownOption, DropDownOptionValue} from "../../../../../../components/common/drop-down.component";
 import {FindSchemaDefinitionsVisitor} from "../../_visitors/schema-definitions.visitor";
 
@@ -89,7 +89,7 @@ export class AddSchemaDialogComponent {
     add(): void {
         if (this.isValid()) {
             let refPrefix: string = "#/components/schemas/";
-            if (this.doc.is2xDocument()) {
+            if (this.doc.getDocumentType() == DocumentType.openapi2) {
                 refPrefix = "#/definitions/";
             }
 

--- a/front-end/studio/yarn.lock
+++ b/front-end/studio/yarn.lock
@@ -249,10 +249,10 @@
   dependencies:
     tslib "^2.0.0"
 
-"@apicurio/data-models@1.1.28":
-  version "1.1.28"
-  resolved "https://artifactory.s.arkea.com/artifactory/api/npm/npm/@apicurio/data-models/-/data-models-1.1.28.tgz#49a7a768b1bd49b345b04ffafbdc097d1ea95979"
-  integrity sha512-k7NCgYvRD+uNY9BkGm451wBIhdIiNUQoTHkZ1VZHyJB3Q9QSna5Z5Nl05rEKS723x6X9MSAvu6p21hy6DA3Axw==
+"@apicurio/data-models@1.1.30":
+  version "1.1.30"
+  resolved "https://artifactory.s.arkea.com/artifactory/api/npm/npm/@apicurio/data-models/-/data-models-1.1.30.tgz#be60781eb1296b2cda497e161100d0619f53561b"
+  integrity sha512-6GWSZKRREKiBgqzRfL7QJiTlUaflP0FnFQ02h4W6Jqdtoal247nQRxdyDEPK8s8wmIVJp8MP3zlvWgkLCMOgag==
   dependencies:
     core-js "3.27.2"
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <version.io.quarkus>2.16.4.Final</version.io.quarkus>
 
         <!-- Other Apicurio Projects -->
-        <version.apicurio-data-models>1.1.28</version.apicurio-data-models>
+        <version.apicurio-data-models>1.1.30</version.apicurio-data-models>
         <version.apicurio-registry>1.3.2.Final</version.apicurio-registry>
         <version.apicurio-codegen>1.0.14.Final</version.apicurio-codegen>
 


### PR DESCRIPTION
For asyncapi docs, defining schema with oneOf, allOf or anyOf inheritance isn't working cause required apicurio-data-models commands are missing and `definition-form.component.ts` only supports openapi docs.

This PR upgrades apicurio-data-models to 1.1.30 which brings required commands and adds required modifications to support it.

Marked as draft until  apicurio-data-models 1.1.30 is released.