### PR TITLE
Fix: escape curly brackets that can be found in path items external reference urls

### DIFF
--- a/back-end/hub-core/src/main/java/io/apicurio/hub/core/content/AbstractReferenceResolver.java
+++ b/back-end/hub-core/src/main/java/io/apicurio/hub/core/content/AbstractReferenceResolver.java
@@ -52,7 +52,8 @@ public abstract class AbstractReferenceResolver implements IReferenceResolver {
     @Override
     public Node resolveRef(String reference, Node from) {
         try {
-            URI uri = new URI(reference);
+            // escape curly brackets to handle path items external refs with templates
+            URI uri = new URI(reference.replaceAll("\\{", "%7B").replaceAll("}", "%7D"));
             if (accepts(uri)) {
                 return resolveUriRef(uri, from);
             }


### PR DESCRIPTION
Linked to https://github.com/Apicurio/apicurio-studio/issues/3030.

An openapi doc can have an external reference on a path containing a template. In that case curly brackets will be present in the url and should be escaped before creating a java `URI` to avoid an exception.
